### PR TITLE
After logout, return to / only if that URL is permitted.

### DIFF
--- a/base-component/webroot/screen/webroot/Login.xml
+++ b/base-component/webroot/screen/webroot/Login.xml
@@ -19,6 +19,9 @@ along with this software (see the LICENSE.md file). If not, see
     <transition name="login" require-session-token="false"><actions><script>ec.user.loginUser(username, password, tenantId)</script></actions>
         <default-response type="screen-last"/><error-response url="."/></transition>
     <transition name="logout"><actions><script>ec.user.logoutUser()</script></actions>
+    	<conditional-response url=".">
+    		<condition><expression>!ec.artifactExecutionFacade.isPermitted('AT_XML_SCREEN:AUTHZA_VIEW:component://', ec.user.nowTimestamp, ec)</expression></condition>
+    	</conditional-response>
         <default-response url="/"/><error-response url="."/></transition>
     <transition name="resetPassword"><service-call name="org.moqui.impl.UserServices.reset#Password"/>
         <default-response url="."/></transition>


### PR DESCRIPTION
Otherwise, go to Login. This not only saves one redirection, it also avoids
storing the / with no user as the last screen, so subscreens with a
conditional-response that changes its condition when a user is logged in
will work correctly.