### PR TITLE
Entity name field in entity

### DIFF
--- a/base-component/tools/screen/Tools/Entity/DataEdit/EntityDataEdit.xml
+++ b/base-component/tools/screen/Tools/Entity/DataEdit/EntityDataEdit.xml
@@ -16,24 +16,24 @@ along with this software (see the LICENSE.md file). If not, see
         xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/xml-screen-2.0.xsd"
         default-menu-title="Edit" default-menu-index="3">
 
-    <parameter name="entityName" required="true"/>
+    <parameter name="base_component_tools_EntityUtils_EntityName" required="true"/>
 
     <transition name="list"><default-response url="../EntityList"/></transition>
     <transition name="find"><default-response url="../EntityDataFind"/></transition>
     <transition name="edit"><default-response url="."/></transition>
     <transition name="update">
-        <actions><service-call name="update#${entityName}" in-map="true"/></actions>
-        <default-response url="." parameter-map="ec.entity.getEntityDefinition(entityName).getPrimaryKeys(context)"/>
+        <actions><service-call name="update#${base_component_tools_EntityUtils_EntityName}" in-map="true"/></actions>
+        <default-response url="." parameter-map="ec.entity.getEntityDefinition(base_component_tools_EntityUtils_EntityName).getPrimaryKeys(context)"/>
     </transition>
 
     <actions>
-        <set field="entityDefinition" from="ec.entity.getEntityDefinition(entityName)"/>
+        <set field="entityDefinition" from="ec.entity.getEntityDefinition(base_component_tools_EntityUtils_EntityName)"/>
         <if condition="entityDefinition.getEntityGroupName() == 'tenantcommon'">
             <message error="true">Data find and edit not allowed for entities in the tenantcommon group</message><return/></if>
 
         <set field="dependentLevels" from="(dependentLevels ?: '0') as int"/>
-        <entity-find-one entity-name="${entityName}" value-field="entityValue"/>
-        <set field="relationshipInfoList" from="ec.entity.getEntityDefinition(entityName).getRelationshipsInfo(false)"/>
+        <entity-find-one entity-name="${base_component_tools_EntityUtils_EntityName}" value-field="entityValue"/>
+        <set field="relationshipInfoList" from="ec.entity.getEntityDefinition(base_component_tools_EntityUtils_EntityName).getRelationshipsInfo(false)"/>
         <script>
             if (entityValue) {
                 Map plainMap = entityValue.getPlainValueMap(dependentLevels)
@@ -48,11 +48,11 @@ along with this software (see the LICENSE.md file). If not, see
             <link url="list" text="Entity List"/>
             <link url="find" text="Find"/>
         </container>
-        <container><label text="Edit '${entityName}' Entity Value" type="h3"/></container>
+        <container><label text="Edit '${base_component_tools_EntityUtils_EntityName}' Entity Value" type="h3"/></container>
         <form-single name="UpdateEntityValue" map="entityValue" transition="update" dynamic="true">
-            <auto-fields-entity entity-name="${entityName}" include="pk" field-type="display"/>
-            <auto-fields-entity entity-name="${entityName}" include="nonpk" field-type="edit"/>
-            <field name="entityName" entry-name="entityName"><default-field><hidden/></default-field></field>
+            <auto-fields-entity entity-name="${base_component_tools_EntityUtils_EntityName}" include="pk" field-type="display"/>
+            <auto-fields-entity entity-name="${base_component_tools_EntityUtils_EntityName}" include="nonpk" field-type="edit"/>
+            <field name="base_component_tools_EntityUtils_EntityName" entry-name="base_component_tools_EntityUtils_EntityName"><default-field title="Entity Name"><hidden/></default-field></field>
             <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
         </form-single>
         <form-list name="RelatedEntities" list="relationshipInfoList" list-entry="relInfo">
@@ -65,12 +65,12 @@ along with this software (see the LICENSE.md file). If not, see
             <field name="link">
                 <conditional-field condition="relInfo.type == 'many' &amp;&amp; targetParameterMap">
                     <link text="Find" url="find" parameter-map="targetParameterMap">
-                        <parameter name="entityName" from="relInfo.relatedEntityName"/>
+                        <parameter name="base_component_tools_EntityUtils_EntityName" from="relInfo.relatedEntityName"/>
                     </link>
                 </conditional-field>
                 <conditional-field condition="targetParameterMap">
                     <link text="Edit" url="edit" parameter-map="targetParameterMap">
-                        <parameter name="entityName" from="relInfo.relatedEntityName"/>
+                        <parameter name="base_component_tools_EntityUtils_EntityName" from="relInfo.relatedEntityName"/>
                     </link>
                 </conditional-field>
                 <default-field><display text=" "/></default-field>
@@ -78,8 +78,8 @@ along with this software (see the LICENSE.md file). If not, see
         </form-list>
         <label text="JSON with Dependents" type="h5"/>
         <form-single name="LevelsForm" transition="." dynamic="true">
-            <auto-fields-entity entity-name="${entityName}" field-type="hidden" include="pk"/>
-            <field name="entityName"><default-field><hidden/></default-field></field>
+            <auto-fields-entity entity-name="${base_component_tools_EntityUtils_EntityName}" field-type="hidden" include="pk"/>
+            <field name="base_component_tools_EntityUtils_EntityName"><default-field title="Entity Name"><hidden/></default-field></field>
             <field name="dependentLevels"><default-field><text-line size="5"/></default-field></field>
             <field name="submitButton"><default-field title="Submit"><submit/></default-field></field>
             <field-layout><field-row-big><field-ref name="dependentLevels"/><field-ref name="submitButton"/></field-row-big></field-layout>

--- a/base-component/tools/screen/Tools/Entity/DataEdit/EntityDataFind.xml
+++ b/base-component/tools/screen/Tools/Entity/DataEdit/EntityDataFind.xml
@@ -16,32 +16,31 @@ along with this software (see the LICENSE.md file). If not, see
         xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/xml-screen-2.0.xsd"
         default-menu-title="Find" default-menu-index="2">
 
-    <parameter name="entityName" required="true"/>
+    <parameter name="base_component_tools_EntityUtils_EntityName" required="true"/>
 
     <transition name="list"><default-response url="../EntityList"/></transition>
     <transition name="find"><default-response url="."/></transition>
     <transition name="create">
-        <actions><service-call name="create#${entityName}" in-map="true"/></actions>
+        <actions><service-call name="create#${base_component_tools_EntityUtils_EntityName}" in-map="true"/></actions>
         <default-response url="."/>
     </transition>
     <transition name="listSubmit">
         <actions>
             <if condition="delete">
-                <service-call name="delete#${entityName}" in-map="true"/>
+                <service-call name="delete#${base_component_tools_EntityUtils_EntityName}" in-map="true"/>
             </if>
         </actions>
         <conditional-response url=".">
             <condition><expression>delete</expression></condition>
         </conditional-response>
-        <default-response url="../EntityDataEdit" parameter-map="ec.entity.getEntityDefinition(entityName).getPrimaryKeys(context)"/>
+        <default-response url="../EntityDataEdit" parameter-map="ec.entity.getEntityDefinition(base_component_tools_EntityUtils_EntityName).getPrimaryKeys(context)"/>
     </transition>
 
     <actions>
-        <set field="entityDefinition" from="ec.entity.getEntityDefinition(entityName)"/>
+        <set field="entityDefinition" from="ec.entity.getEntityDefinition(base_component_tools_EntityUtils_EntityName)"/>
         <if condition="entityDefinition.getEntityGroupName() == 'tenantcommon'">
             <message error="true">Data find and edit not allowed for entities in the tenantcommon group</message><return/></if>
-
-        <entity-find entity-name="${entityName}" list="entityValueList" offset="0" limit="50">
+        <entity-find entity-name="${base_component_tools_EntityUtils_EntityName}" list="entityValueList" offset="0" limit="50">
             <search-form-inputs/>
         </entity-find>
     </actions>
@@ -50,25 +49,25 @@ along with this software (see the LICENSE.md file). If not, see
             <link url="list" text="Entity List"/>
             <container-dialog id="FindValueDialog" button-text="Find">
                 <form-single name="FindEntityValue" transition="find" dynamic="true">
-                    <auto-fields-entity entity-name="${entityName}" field-type="find"/>
-                    <field name="entityName"><default-field><hidden/></default-field></field>
+                    <auto-fields-entity entity-name="${base_component_tools_EntityUtils_EntityName}" field-type="find"/>
+                    <field name="base_component_tools_EntityUtils_EntityName"><default-field title="Entity Name"><hidden/></default-field></field>
                     <field name="submitButton"><default-field title="Find"><submit/></default-field></field>
                 </form-single>
             </container-dialog>
             <container-dialog id="CreateValueDialog" button-text="New Value">
                 <form-single name="CreateEntityValue" transition="create" dynamic="true">
-                    <auto-fields-entity entity-name="${entityName}" field-type="edit"/>
-                    <field name="entityName"><default-field><hidden/></default-field></field>
+                    <auto-fields-entity entity-name="${base_component_tools_EntityUtils_EntityName}" field-type="edit"/>
+                    <field name="base_component_tools_EntityUtils_EntityName"><default-field title="Entity Name"><hidden/></default-field></field>
                     <field name="submitButton"><default-field title="Create"><submit/></default-field></field>
                 </form-single>
             </container-dialog>
         </container>
-        <container><label text="Find '${entityName}' Entity Value" type="h3"/></container>
+        <container><label text="Find '${base_component_tools_EntityUtils_EntityName}' Entity Value" type="h3"/></container>
         <form-list name="ListEntityValue" list="entityValueList" transition="listSubmit" multi="false" dynamic="true">
-            <field name="entityName"><default-field><hidden/></default-field></field>
+            <field name="base_component_tools_EntityUtils_EntityName"><default-field title="Entity Name"><hidden/></default-field></field>
             <field name="edit"><default-field title="Edit"><submit/></default-field></field>
             <field name="delete"><default-field title="Delete"><submit/></default-field></field>
-            <auto-fields-entity entity-name="${entityName}" field-type="display"/>
+            <auto-fields-entity entity-name="${base_component_tools_EntityUtils_EntityName}" field-type="display"/>
         </form-list>
     </widgets>
 </screen>

--- a/base-component/tools/screen/Tools/Entity/DataEdit/EntityDetail.xml
+++ b/base-component/tools/screen/Tools/Entity/DataEdit/EntityDetail.xml
@@ -16,22 +16,22 @@ along with this software (see the LICENSE.md file). If not, see
         xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/xml-screen-2.0.xsd"
         default-menu-title="Entity Detail">
 
-    <parameter name="entityName" required="true"/>
+    <parameter name="base_component_tools_EntityUtils_EntityName" required="true"/>
     <parameter name="refresh" required="false"/>
 
     <transition name="list"><default-response url="../EntityList"/></transition>
     <transition name="find"><default-response url="../EntityDataFind"/></transition>
     <transition name="checkTable">
-        <actions><script>ec.entity.entityDbMeta.forceCheckTableRuntime(ec.entity.getEntityDefinition(entityName))</script></actions>
+        <actions><script>ec.entity.entityDbMeta.forceCheckTableRuntime(ec.entity.getEntityDefinition(base_component_tools_EntityUtils_EntityName))</script></actions>
         <default-response url="."/>
     </transition>
 
     <actions>
-        <set field="entityDefinition" from="ec.entity.getEntityDefinition(entityName)"/>
+        <set field="entityDefinition" from="ec.entity.getEntityDefinition(base_component_tools_EntityUtils_EntityName)"/>
         <set field="entityNode" from="entityDefinition.getEntityNode()"/>
         <set field="fieldNodes" from="entityDefinition.getFieldNodes(true, true, false)"/>
         <entity-find entity-name="moqui.entity.UserField" list="userFieldList">
-            <econdition field-name="entityName" from="entityDefinition.fullEntityName"/>
+            <econdition field-name="base_component_tools_EntityUtils_EntityName" from="entityDefinition.fullEntityName"/>
             <order-by field-name="fieldName"/>
         </entity-find>
         <set field="relationshipInfoList" from="entityDefinition.getRelationshipsInfo(false)"/>
@@ -85,8 +85,8 @@ along with this software (see the LICENSE.md file). If not, see
             <field name="keyMap"><default-field><display/></default-field></field>
             <field name="link">
                 <default-field title="">
-                    <link text="Detail" url="." link-type="anchor"><parameter name="entityName" from="relInfo.relatedEntityName"/></link>
-                    <link text="Find" url="find" link-type="anchor"><parameter name="entityName" from="relInfo.relatedEntityName"/></link>
+                    <link text="Detail" url="." link-type="anchor"><parameter name="base_component_tools_EntityUtils_EntityName" from="relInfo.relatedEntityName"/></link>
+                    <link text="Find" url="find" link-type="anchor"><parameter name="base_component_tools_EntityUtils_EntityName" from="relInfo.relatedEntityName"/></link>
                 </default-field>
             </field>
         </form-list>
@@ -95,7 +95,7 @@ along with this software (see the LICENSE.md file). If not, see
         <label text="${dependents.toString()}" type="pre" encode="true"/>
         <label text="All Descendants:" type="h5"/>
         <section-iterate name="DescendantList" list="dependents.allDescendants" entry="descendantName">
-            <widgets><container><link url="." text="${descendantName}" parameter-map="[entityName:descendantName]" link-type="anchor"/></container></widgets>
+            <widgets><container><link url="." text="${descendantName}" parameter-map="[base_component_tools_EntityUtils_EntityName:descendantName]" link-type="anchor"/></container></widgets>
         </section-iterate>
     </widgets>
 </screen>

--- a/base-component/tools/screen/Tools/Entity/DataEdit/EntityList.xml
+++ b/base-component/tools/screen/Tools/Entity/DataEdit/EntityList.xml
@@ -50,10 +50,10 @@ along with this software (see the LICENSE.md file). If not, see
                 <default-field><display also-hidden="false"/></default-field>
             </field>
             <field name="Find"><default-field>
-                <link url="find" text="Find" link-type="anchor"/>
+                <link url="find" text="Find" link-type="anchor" parameter-map="[base_component_tools_EntityUtils_EntityName:entityName]"/>
             </default-field></field>
             <field name="Detail"><default-field>
-                <link url="detail" text="Detail" link-type="anchor" parameter-map="[entityName:fullEntityName]"/>
+                <link url="detail" text="Detail" link-type="anchor" parameter-map="[base_component_tools_EntityUtils_EntityName:fullEntityName]"/>
             </default-field></field>
         </form-list>
     </widgets>


### PR DESCRIPTION
EntityDataFind screen fails to show any rows for entity mantle.basic.LocalizedEntityField. The problem is that the screen parameter "entityName", used to dynamically identify the entity to search for, also gets used as the value to search for in the entity's "entityName" field.
Here the parameter name is changed to avoid this collision.