### PR TITLE
Redirect from /Login to / when a user is already logged in.

### DIFF
--- a/base-component/webroot/screen/webroot/Login.xml
+++ b/base-component/webroot/screen/webroot/Login.xml
@@ -28,6 +28,9 @@ along with this software (see the LICENSE.md file). If not, see
         <default-response url="../Login"/><error-response url="."/></transition>
 
     <pre-actions><script>
+        if (ec.user.currentInfo?.userAccount) {
+            sri.sendRedirectAndStopRender('/')
+        }
         // jQuery/UI
         html_scripts.add('/lib/jquery/jquery.min.js')
         // Bootstrap


### PR DESCRIPTION
When a user is already logged in and goes to the login page, the application seems to not be working because when the user sends his username and password, he gets redirected to the same Login page over and over.
This happens specially when the user bookmarks the login page and tries to access the app using this bookmark and has not previously logged out.
This change detects when a user is already logged in before rendering the Login page and if so, redirects to the root of the webapp so the default page can get rendered.