### PR TITLE
Minor enhancements to the entity and service details screens

### DIFF
--- a/base-component/tools/screen/Tools/Entity.xml
+++ b/base-component/tools/screen/Tools/Entity.xml
@@ -15,7 +15,7 @@ along with this software (see the LICENSE.md file). If not, see
 <screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/xml-screen-2.0.xsd"
         default-menu-title="Entity" default-menu-index="5">
-    <subscreens default-item="DataImport"/>
+    <subscreens default-item="DataEdit"/>
     <widgets>
         <subscreens-panel id="entity-panel" type="popup"/>
     </widgets>

--- a/base-component/tools/screen/Tools/Service/ServiceDetail.xml
+++ b/base-component/tools/screen/Tools/Service/ServiceDetail.xml
@@ -18,6 +18,9 @@ along with this software (see the LICENSE.md file). If not, see
 
     <parameter name="serviceName" required="true"/>
 
+    <transition name="serviceReference">
+        <default-response url="../ServiceReference"/>
+    </transition>
     <transition name="serviceRun">
         <default-response url="../ServiceRun"/>
     </transition>
@@ -33,6 +36,11 @@ along with this software (see the LICENSE.md file). If not, see
         <set field="outParameterNodes" from="serviceNode.first('out-parameters')?.children('parameter')"/>
     </actions>
     <widgets>
+        <container>
+            <link url="serviceReference" text="Service List"/>
+            <link url="serviceRun" text="Run Service"/>
+        </container>
+
         <label type="h2" text="${sd.serviceName}"/>
         <label type="strong" text="${serviceNode.first('description')?.text ?: ''}" display-if-empty="false"/>
         <!-- <label type="p" text="${serviceNode.attributes}"/> -->
@@ -75,7 +83,7 @@ along with this software (see the LICENSE.md file). If not, see
                         style="language-groovy" encode="false"/></container>
             </widgets>
         </section>
-        <section name="LocationDisplaySection" condition="sd.serviceNode.attribute('location')">
+        <section name="LocationDisplaySection" condition="sd.serviceNode.attribute('location') &amp;&amp; sd.serviceNode.attribute('type')!='java'">
             <widgets>
                 <label text="Script" type="h3"/>
                 <container type="pre" style="line-numbers"><label text="${ec.resource.getLocationText(sd.serviceNode.attribute('location'), false)}"


### PR DESCRIPTION
- Added the service list and run buttons in the service details page.
- Added a service details page condition to skip displaying the script for JAVA-based services
- Set the default Entity sub-screen item to DataEdit.