### PR TITLE
Fix roundtrip for hidden fields.

### DIFF
--- a/template/screen-macro/DefaultScreenMacros.html.ftl
+++ b/template/screen-macro/DefaultScreenMacros.html.ftl
@@ -1703,7 +1703,7 @@ a => A, d => D, y => Y
     <#t><#if dispHidden>
         <#-- use getFieldValuePlainString() and not getFieldValueString() so we don't do timezone conversions, etc -->
         <#-- don't default to fieldValue for the hidden input value, will only be different from the entry value if @text is used, and we don't want that in the hidden value -->
-        <input type="hidden" id="${dispFieldId}" name="<@fieldName .node/>" value="${sri.getFieldValuePlainString(dispFieldNode, "")?html}"<#if ownerForm?has_content> form="${ownerForm}"</#if>>
+        <input type="hidden" id="${dispFieldId}" name="<@fieldName .node/>" value="${sri.getFieldValueString(dispFieldNode, "", null)?html}"<#if ownerForm?has_content> form="${ownerForm}"</#if>>
     </#if>
     <#if .node["@dynamic-transition"]?has_content>
         <#assign defUrlInfo = sri.makeUrlByType(.node["@dynamic-transition"], "transition", .node, "false")>

--- a/template/screen-macro/DefaultScreenMacros.vuet.ftl
+++ b/template/screen-macro/DefaultScreenMacros.vuet.ftl
@@ -1344,7 +1344,7 @@ a => A, d => D, y => Y
     <#t><#if dispHidden>
         <#-- use getFieldValuePlainString() and not getFieldValueString() so we don't do timezone conversions, etc -->
         <#-- don't default to fieldValue for the hidden input value, will only be different from the entry value if @text is used, and we don't want that in the hidden value -->
-        <input type="hidden" id="${dispFieldId}" name="${dispFieldName}" <#if fieldsJsName?has_content>:value="${fieldsJsName}.${dispFieldName}"<#else>value="${sri.getFieldValuePlainString(dispFieldNode, "")?html}"</#if><#if ownerForm?has_content> form="${ownerForm}"</#if>>
+        <input type="hidden" id="${dispFieldId}" name="${dispFieldName}" <#if fieldsJsName?has_content>:value="${fieldsJsName}.${dispFieldName}"<#else>value="${sri.getFieldValueString(dispFieldNode, "", null)?html}"</#if><#if ownerForm?has_content> form="${ownerForm}"</#if>>
     </#if>
     <#if .node["@dynamic-transition"]?has_content>
         <#assign defUrlInfo = sri.makeUrlByType(.node["@dynamic-transition"], "transition", .node, "false")>


### PR DESCRIPTION
This change attempts to fix https://github.com/moqui/moqui-framework/issues/49.
Please revise as the comments indicate that the use of getFieldValuePlainString instead of getFieldValueString is quite intentional to avoid timezone conversions, so this change might trigger problems in other areas. Perhaps we should use getFieldValueString or getFieldValuePlainString depending on the type?
But the general idea is that we should send the data in the same format (and timezone?) as the user would enter it, because when we receive that data from the form it should be indistinguishable if the source is a hidden field or a user-entered field.
This change solves the problem of a decimal number stored in the database which is included in a hidden field and then received back in a service that updates the same entity it came from. Now the same number is maintained when the uaser's locale uses ',' as decimal separator and '.' as thousands separator.
An example is /apps/hm/Task/EditTask when the actualWorkTime field has a decimal number (e.g. 0,1 in es_CL locale, 0.1 in en_US locale). Without this change, the 0.1 would be converted to a 1.0 on any change because of the hidden field being wrongly interpreted when receiving the data from the browser.