### PR TITLE
fix an issue when transition with default-response type="none"  while submitting a form

### DIFF
--- a/template/screen-macro/DefaultScreenMacros.vuet.ftl
+++ b/template/screen-macro/DefaultScreenMacros.vuet.ftl
@@ -359,12 +359,13 @@ ${sri.renderIncludeScreen(.node["@location"], .node["@share-scope"]!)}
         <#if urlInstance.getTargetTransition()?has_content><#assign formSingleType = "m-form"><#else><#assign formSingleType = "form-link"></#if>
     <#else><#assign formSingleType = "form"></#if>
     <#if !skipStart>
-    <${formSingleType} name="${formId}" id="${formId}" action="${urlInstance.path}"<#if formNode["@focus-field"]?has_content> focus-field="${formNode["@focus-field"]}"</#if><#rt>
+    <${formSingleType} name="${formId}" id="${formId}" method="post" action="${urlInstance.path}"<#if formNode["@focus-field"]?has_content> focus-field="${formNode["@focus-field"]}"</#if><#rt>
             <#t><#if formNode["@body-parameters"]?has_content> :body-parameter-names="[<#list formNode["@body-parameters"]?split(",") as bodyParm>'${bodyParm}'<#sep>,</#list>]"</#if>
             <#t><#if formNode["@background-message"]?has_content> submit-message="${formNode["@background-message"]?html}"</#if>
             <#t><#if formNode["@background-reload-id"]?has_content> submit-reload-id="${formNode["@background-reload-id"]}"</#if>
             <#t><#if formNode["@background-hide-id"]?has_content> submit-hide-id="${formNode["@background-hide-id"]}"</#if>>
         <input type="hidden" name="moquiFormName" value="${formNode["@name"]}">
+        <#if formSingleType == "form"><input type="hidden" name="moquiSessionToken" value="${(ec.getWeb().sessionToken)!}"></#if>
         <#assign lastUpdatedString = sri.getNamedValuePlain("lastUpdatedStamp", formNode)>
         <#if lastUpdatedString?has_content><input type="hidden" name="lastUpdatedStamp" value="${lastUpdatedString}"></#if>
     </#if>


### PR DESCRIPTION
When submitting a form, while I want the transition to response a JSON with the type="none" not an url to reload the page, it will encounter an error cause by the CSRF/XSRF checking because of the form is not post form but a get form by default.
I know the transition can be defined as 'readOnly' to avoid this, but I think this is a better way