### PR TITLE
feat: enable /status for health check and docker host heartbeat check

### DIFF
--- a/base-component/webroot/screen/webroot.xml
+++ b/base-component/webroot/screen/webroot.xml
@@ -23,12 +23,18 @@ along with this software (see the LICENSE.md file). If not, see
         <!-- See WebrootThemeData.xml for CSS references -->
         <set field="html_stylesheets" from="new LinkedHashSet()"/>
     </always-actions>
-    <!-- needs to be secured, require authc and a permission:
     <transition name="status">
-        <actions><script>ec.web.sendJsonResponse(ec.factory.getStatusMap())</script></actions>
+        <actions>
+            <set field="allowed_ips" from="['127.0.0.1']"/>
+            <if condition="System.getenv('DOCKER_HOST_IPS')"><script>allowed_ips.addAll(System.getenv('DOCKER_HOST_IPS').replaceAll("\\s", "").split(","))</script></if>
+            <if condition="ec.web.getRequest().getRemoteAddr() in allowed_ips"><then>
+                <script>ec.web.sendJsonResponse(ec.factory.getStatusMap())</script>
+            </then><else>
+                <log message="Rejecting /status from ${ec.web.getRequest().getRemoteAddr()}"/>
+            </else></if>
+        </actions>
         <default-response type="none"/>
     </transition>
-    -->
     <transition name="menuData" read-only="true" begin-transaction="false">
         <actions><script><![CDATA[
             List menuDataList = sri.getMenuData(sri.screenUrlInfo.extraPathNameList)

--- a/base-component/webroot/screen/webroot.xml
+++ b/base-component/webroot/screen/webroot.xml
@@ -25,7 +25,7 @@ along with this software (see the LICENSE.md file). If not, see
     </always-actions>
     <transition name="status">
         <actions>
-            <set field="allowed_ips" from="System.getProperty('instance_docker_host_ips')? System.getProperty('instance_docker_host_ips').replaceAll('\\s', '').split(',')+['127.0.0.1']: ['127.0.0.1']"/>
+            <set field="allowed_ips" from="System.getProperty('webapp_status_ips')? System.getProperty('webapp_status_ips').replaceAll('\\s', '').split(',')+['127.0.0.1']: ['127.0.0.1']"/>
             <if condition="ec.web.getRequest().getRemoteAddr() in allowed_ips"><then>
                 <script>ec.web.sendJsonResponse(ec.factory.getStatusMap())</script>
             </then><else>

--- a/base-component/webroot/screen/webroot.xml
+++ b/base-component/webroot/screen/webroot.xml
@@ -25,8 +25,7 @@ along with this software (see the LICENSE.md file). If not, see
     </always-actions>
     <transition name="status">
         <actions>
-            <set field="allowed_ips" from="['127.0.0.1']"/>
-            <if condition="System.getenv('DOCKER_HOST_IPS')"><script>allowed_ips.addAll(System.getenv('DOCKER_HOST_IPS').replaceAll("\\s", "").split(","))</script></if>
+            <set field="allowed_ips" from="System.getProperty('instance_docker_host_ips')? System.getProperty('instance_docker_host_ips').replaceAll('\\s', '').split(',')+['127.0.0.1']: ['127.0.0.1']"/>
             <if condition="ec.web.getRequest().getRemoteAddr() in allowed_ips"><then>
                 <script>ec.web.sendJsonResponse(ec.factory.getStatusMap())</script>
             </then><else>


### PR DESCRIPTION
Enable /status transition for selected IPs (127.0.0.1 for docker health check, obtain docker host IP from environment variable).