### PR TITLE
Change "find related entity" link to automatically show relevant entries

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,6 +50,7 @@ Written in 2016 by Mark Haney - mphaney
 Written in 2018 by Nirendra Singh Panwar - nirendra10695
 Written in 2018 by Zhang Wei - zhangwei1979
 Written in 2019 by Jacob Barnes - Tellan
+Written in 2019 by Arzang Kasiri - akasiri
 
 ===========================================================================
 
@@ -86,3 +87,4 @@ Written in 2016 by Mark Haney - mphaney
 Written in 2018 by Nirendra Singh Panwar - nirendra10695
 Written in 2018 by Zhang Wei - zhangwei1979
 Written in 2019 by Jacob Barnes - Tellan
+Written in 2019 by Arzang Kasiri - akasiri

--- a/base-component/tools/screen/Tools/Entity/DataEdit/EntityDetail.xml
+++ b/base-component/tools/screen/Tools/Entity/DataEdit/EntityDetail.xml
@@ -88,7 +88,11 @@ along with this software (see the LICENSE.md file). If not, see
             <field name="link">
                 <default-field title="">
                     <link text="Detail" url="." link-type="anchor"><parameter name="selectedEntity" from="relInfo.relatedEntityName"/></link>
-                    <link text="Find" url="find" link-type="anchor"><parameter name="selectedEntity" from="relInfo.relatedEntityName"/></link>
+                    <link text="Find" url="find" link-type="anchor">
+                        <parameter name="enumTypeId" value="${(relInfo.relatedEntityName == &quot;moqui.basic.Enumeration&quot;)? relInfo.title : &quot;&quot;}"/> <!-- optional parameter. only assigns a value if relInfo is an Enumeration -->
+                        <parameter name="statusTypeId" value="${(relInfo.relatedEntityName == &quot;moqui.basic.StatusItem&quot;)? relInfo.title : &quot;&quot;}"/> <!-- optional parameter. only assigns a value if relInfo is a StatusItem -->
+                        <parameter name="selectedEntity" from="relInfo.relatedEntityName"/>
+                    </link>
                 </default-field>
             </field>
         </form-list>

--- a/base-component/webroot/data/WebrootThemeData.xml
+++ b/base-component/webroot/data/WebrootThemeData.xml
@@ -56,4 +56,8 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.screen.ScreenThemeResource screenThemeId="DEFAULT" sequenceNum="201" resourceTypeEnumId="STRT_FOOTER_ITEM">
         <resourceValue><![CDATA[<p><a href="/apps/ScreenTree">${ec.l10n.localize('Site Map')}</a></p>]]></resourceValue>
     </moqui.screen.ScreenThemeResource>
+
+    <!-- Icon resource location -->
+    <moqui.screen.ScreenThemeResource screenThemeId="DEFAULT" sequenceNum="301" resourceTypeEnumId="STRT_SHORTCUT_ICON_LOCATION"
+            resourceValue="component://webroot/screen/webroot/favicon.ico"/>
 </entity-facade-xml>

--- a/base-component/webroot/screen/webroot.xml
+++ b/base-component/webroot/screen/webroot.xml
@@ -58,6 +58,18 @@ along with this software (see the LICENSE.md file). If not, see
         <default-response type="none"/>
     </transition>
 
+    <transition name="favicon.ico">
+        <actions>
+            <!-- change the location in the ScreenThemeResource of type STRT_SHORTCUT_ICON_LOCATION to the location of whatever favicon you would like -->
+            <script>
+                resourceLocation = sri.getThemeValues("STRT_SHORTCUT_ICON_LOCATION")
+                if (resourceLocation) ec.web.sendResourceResponse(resourceLocation)
+                else ec.logger.error("In base-component/webroot/screen/webroot.xml: Unable to load favicon")
+            </script>
+        </actions>
+        <default-response type="none"/>
+    </transition>
+
     <subscreens default-item="vapps">
         <subscreens-item name="toolstatic" location="component://tools/screen/toolstatic.xml" menu-include="false"/>
         <!-- add UNDECORATED (or self-decorating) app roots here -->

--- a/base-component/webroot/screen/webroot.xml
+++ b/base-component/webroot/screen/webroot.xml
@@ -64,7 +64,7 @@ along with this software (see the LICENSE.md file). If not, see
             <script>
                 resourceLocation = sri.getThemeValues("STRT_SHORTCUT_ICON_LOCATION")
                 if (resourceLocation) ec.web.sendResourceResponse(resourceLocation)
-                else ec.logger.error("In base-component/webroot/screen/webroot.xml: Unable to load favicon")
+                else ec.web.sendResourceResponse("component://webroot/screen/webroot/favicon.ico")
             </script>
         </actions>
         <default-response type="none"/>


### PR DESCRIPTION
Changed the Find anchor link in the related entities list in the EntityDetail page to, when pulling up Enumerations and StatusItems, only search for results that are relevant to the entity the user was previously looking at.