### PR TITLE
Change "find related entity" link to automatically show relevant entries

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,6 +50,7 @@ Written in 2016 by Mark Haney - mphaney
 Written in 2018 by Nirendra Singh Panwar - nirendra10695
 Written in 2018 by Zhang Wei - zhangwei1979
 Written in 2019 by Jacob Barnes - Tellan
+Written in 2019 by Arzang Kasiri - akasiri
 
 ===========================================================================
 
@@ -86,3 +87,4 @@ Written in 2016 by Mark Haney - mphaney
 Written in 2018 by Nirendra Singh Panwar - nirendra10695
 Written in 2018 by Zhang Wei - zhangwei1979
 Written in 2019 by Jacob Barnes - Tellan
+Written in 2019 by Arzang Kasiri - akasiri

--- a/base-component/tools/screen/Tools/Entity/DataEdit/EntityDetail.xml
+++ b/base-component/tools/screen/Tools/Entity/DataEdit/EntityDetail.xml
@@ -89,8 +89,8 @@ along with this software (see the LICENSE.md file). If not, see
                 <default-field title="">
                     <link text="Detail" url="." link-type="anchor"><parameter name="selectedEntity" from="relInfo.relatedEntityName"/></link>
                     <link text="Find" url="find" link-type="anchor">
-                        <parameter name="enumTypeId" value="${(relInfo.relatedEntityName == &quot;moqui.basic.Enumeration&quot;)? relInfo.title : &quot;&quot;}"/> <!-- optional parameter. only assigns a value if relInfo is an Enumeration -->
-                        <parameter name="statusTypeId" value="${(relInfo.relatedEntityName == &quot;moqui.basic.StatusItem&quot;)? relInfo.title : &quot;&quot;}"/> <!-- optional parameter. only assigns a value if relInfo is a StatusItem -->
+                        <parameter name="enumTypeId" from="(relInfo.relatedEntityName == 'moqui.basic.Enumeration')? relInfo.title : ''"/> <!-- optional parameter. only assigns a value if relInfo is an Enumeration -->
+                        <parameter name="statusTypeId" from="(relInfo.relatedEntityName == 'moqui.basic.StatusItem')? relInfo.title : ''"/> <!-- optional parameter. only assigns a value if relInfo is a StatusItem -->
                         <parameter name="selectedEntity" from="relInfo.relatedEntityName"/>
                     </link>
                 </default-field>

--- a/base-component/tools/screen/Tools/Entity/DataEdit/EntityDetail.xml
+++ b/base-component/tools/screen/Tools/Entity/DataEdit/EntityDetail.xml
@@ -88,7 +88,11 @@ along with this software (see the LICENSE.md file). If not, see
             <field name="link">
                 <default-field title="">
                     <link text="Detail" url="." link-type="anchor"><parameter name="selectedEntity" from="relInfo.relatedEntityName"/></link>
-                    <link text="Find" url="find" link-type="anchor"><parameter name="selectedEntity" from="relInfo.relatedEntityName"/></link>
+                    <link text="Find" url="find" link-type="anchor">
+                        <parameter name="enumTypeId" value="${(relInfo.relatedEntityName == &quot;moqui.basic.Enumeration&quot;)? relInfo.title : &quot;&quot;}"/> <!-- optional parameter. only assigns a value if relInfo is an Enumeration -->
+                        <parameter name="statusTypeId" value="${(relInfo.relatedEntityName == &quot;moqui.basic.StatusItem&quot;)? relInfo.title : &quot;&quot;}"/> <!-- optional parameter. only assigns a value if relInfo is a StatusItem -->
+                        <parameter name="selectedEntity" from="relInfo.relatedEntityName"/>
+                    </link>
                 </default-field>
             </field>
         </form-list>


### PR DESCRIPTION
Changed the Find anchor link in the related entities list in the EntityDetail page to, when pulling up Enumerations and StatusItems, only search for results that are relevant to the entity the user was previously looking at.

(re-submitting PR because I needed to put this on a separate branch)