### PR TITLE
Load custom favicon from a location stored in the database

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,6 +50,7 @@ Written in 2016 by Mark Haney - mphaney
 Written in 2018 by Nirendra Singh Panwar - nirendra10695
 Written in 2018 by Zhang Wei - zhangwei1979
 Written in 2019 by Jacob Barnes - Tellan
+Written in 2019 by Arzang Kasiri - akasiri
 
 ===========================================================================
 
@@ -86,3 +87,4 @@ Written in 2016 by Mark Haney - mphaney
 Written in 2018 by Nirendra Singh Panwar - nirendra10695
 Written in 2018 by Zhang Wei - zhangwei1979
 Written in 2019 by Jacob Barnes - Tellan
+Written in 2019 by Arzang Kasiri - akasiri

--- a/base-component/webroot/data/WebrootThemeData.xml
+++ b/base-component/webroot/data/WebrootThemeData.xml
@@ -56,4 +56,8 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.screen.ScreenThemeResource screenThemeId="DEFAULT" sequenceNum="201" resourceTypeEnumId="STRT_FOOTER_ITEM">
         <resourceValue><![CDATA[<p><a href="/apps/ScreenTree">${ec.l10n.localize('Site Map')}</a></p>]]></resourceValue>
     </moqui.screen.ScreenThemeResource>
+
+    <!-- Icon resource location -->
+    <moqui.screen.ScreenThemeResource screenThemeId="DEFAULT" sequenceNum="301" resourceTypeEnumId="STRT_SHORTCUT_ICON_LOCATION"
+            resourceValue="component://webroot/screen/webroot/favicon.ico"/>
 </entity-facade-xml>

--- a/base-component/webroot/data/WebrootThemeData.xml
+++ b/base-component/webroot/data/WebrootThemeData.xml
@@ -56,8 +56,4 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.screen.ScreenThemeResource screenThemeId="DEFAULT" sequenceNum="201" resourceTypeEnumId="STRT_FOOTER_ITEM">
         <resourceValue><![CDATA[<p><a href="/apps/ScreenTree">${ec.l10n.localize('Site Map')}</a></p>]]></resourceValue>
     </moqui.screen.ScreenThemeResource>
-
-    <!-- Icon resource location -->
-    <moqui.screen.ScreenThemeResource screenThemeId="DEFAULT" sequenceNum="301" resourceTypeEnumId="STRT_SHORTCUT_ICON_LOCATION"
-            resourceValue="component://webroot/screen/webroot/favicon.ico"/>
 </entity-facade-xml>

--- a/base-component/webroot/screen/webroot.xml
+++ b/base-component/webroot/screen/webroot.xml
@@ -58,6 +58,18 @@ along with this software (see the LICENSE.md file). If not, see
         <default-response type="none"/>
     </transition>
 
+    <transition name="favicon.ico">
+        <actions>
+            <!-- change the location in the ScreenThemeResource of type STRT_SHORTCUT_ICON_LOCATION to the location of whatever favicon you would like -->
+            <script>
+                resourceLocation = sri.getThemeValues("STRT_SHORTCUT_ICON_LOCATION")
+                if (resourceLocation) ec.web.sendResourceResponse(resourceLocation)
+                else ec.web.sendResourceResponse("component://webroot/screen/webroot/favicon.ico")
+            </script>
+        </actions>
+        <default-response type="none"/>
+    </transition>
+
     <subscreens default-item="vapps">
         <subscreens-item name="toolstatic" location="component://tools/screen/toolstatic.xml" menu-include="false"/>
         <!-- add UNDECORATED (or self-decorating) app roots here -->

--- a/base-component/webroot/screen/webroot.xml
+++ b/base-component/webroot/screen/webroot.xml
@@ -58,13 +58,13 @@ along with this software (see the LICENSE.md file). If not, see
         <default-response type="none"/>
     </transition>
 
+    <!-- Force custom favicon, if set in the "STRT_SHORTCUT_ICON" ScreenThemeResource. -->
     <transition name="favicon.ico">
         <actions>
-            <!-- change the location in the ScreenThemeResource of type STRT_SHORTCUT_ICON_LOCATION to the location of whatever favicon you would like -->
             <script>
-                resourceLocation = sri.getThemeValues("STRT_SHORTCUT_ICON_LOCATION")
-                if (resourceLocation) ec.web.sendResourceResponse(resourceLocation)
-                else ec.web.sendResourceResponse("component://webroot/screen/webroot/favicon.ico")
+                iconList = sri.getThemeValues("STRT_SHORTCUT_ICON")
+                if (!iconList || iconList[0] == "") iconList = ["/favicon.ico"]
+                ec.web.sendResourceResponse("component://webroot/screen/webroot" + iconList[0])
             </script>
         </actions>
         <default-response type="none"/>


### PR DESCRIPTION
Added in a transition in webroot.xml to attempt to load a custom favicon from a resource location stored in a ScreenThemeResource. If not found, the transition loads the default favicon.ico. 

Requires an enum ("STRT_SHORTCUT_ICON_LOCATION") found in moqui-framework. I'm making a PR there too for that enum.