### PR TITLE
feat: add moqui_http_log search/display to LogViewer screen

### DIFF
--- a/base-component/tools/screen/System/LogViewer.xml
+++ b/base-component/tools/screen/System/LogViewer.xml
@@ -98,7 +98,8 @@ along with this software (see the LICENSE.md file). If not, see
         <link url="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax"
                 url-type="plain" link-type="anchor" target-window="_blank" text="Query String Reference"/>
         <form-single name="SearchOptions" transition=".">
-            <field name="indexName"><default-field title=""><text-line size="12" default-value="moqui_logs"/></default-field></field>
+            <field name="indexName"><default-field title="">
+                <drop-down><option key="moqui_logs"/><option key="moqui_http_log"/></drop-down></default-field></field>
             <field name="queryString"><default-field title=""><text-line size="60"/></default-field></field>
             <field name="tsPeriod"><default-field title=""><date-period time="true"/></default-field></field>
             <field name="submitButton"><default-field title="Search"><submit/></default-field></field>
@@ -112,38 +113,86 @@ along with this software (see the LICENSE.md file). If not, see
             <container><label text="${messageInfo.message}" type="strong" style="text-${messageInfo.typeString}"/></container>
         </widgets></section-iterate>
 
-        <form-list name="LogMessageDocuments" list="documentList" paginate="true" paginate-always-show="true" skip-form="true">
-            <row-actions>
-                <set field="levelStyle" from="'ERROR'.equals(level) ? 'text-danger' : ('WARN'.equals(level) ? 'text-warning' : ('INFO'.equals(level) ? 'text-success' : ''))"/>
-            </row-actions>
-            <field name="@timestamp"><default-field container-style="text-nowrap ${levelStyle}">
-                <display text="${ec.l10n.format(new Timestamp(context.get('@timestamp')), 'yyyy-MM-dd HH:mm:ss.SSS')}" encode="false"/></default-field></field>
-            <field name="thread_name"><default-field title="thread_name" container-style="text-nowrap ${levelStyle}"><display text="${thread_name}(${thread_id}:${thread_priority})"/></default-field></field>
-            <field name="level"><default-field title="level" container-style="${levelStyle}"><display/></default-field></field>
-            <field name="source_host"><default-field title="source_host" container-style="text-nowrap ${levelStyle}"><display/></default-field></field>
-            <field name="user_id"><default-field title="user_id">
-                <link url="userAccountDetail" text="${user_id}" link-type="anchor" parameter-map="[userId:user_id]" condition="user_id"/></default-field></field>
-            <field name="visitor_id"><default-field title="visitor_id" container-style="${levelStyle}"><display/></default-field></field>
+        <section name="MoquiLog" condition="indexName == 'moqui_logs'"><widgets>
 
-            <field name="logger_name"><default-field title="logger_name" container-style="${levelStyle}"><display/></default-field></field>
-            <field name="message">
-                <conditional-field condition="message != null &amp;&amp; message.length() &gt; 300">
-                    <display text="${message.substring(0, 300)} "/>
-                    <container-dialog id="ViewMessage" button-text="All" width="800"><label text="${message}"/></container-dialog>
-                </conditional-field>
-                <default-field title="message"><display/></default-field>
-            </field>
-            <field name="thrownView"><conditional-field condition="thrown">
-                <container-dialog id="ViewThrown" button-text="Thrown" width="960">
-                    <label text="${groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(thrown))}" type="pre"/>
-                </container-dialog>
-            </conditional-field><default-field title=""><display/></default-field></field>
+            <form-list name="MoquiLogMessageDocuments" list="documentList" paginate="true" paginate-always-show="true" skip-form="true">
+                <row-actions>
+                    <set field="levelStyle" from="'ERROR'.equals(level) ? 'text-danger' : ('WARN'.equals(level) ? 'text-warning' : ('INFO'.equals(level) ? 'text-success' : ''))"/>
+                </row-actions>
+                <field name="@timestamp"><default-field container-style="text-nowrap ${levelStyle}">
+                    <display text="${ec.l10n.format(new Timestamp(context.get('@timestamp')), 'yyyy-MM-dd HH:mm:ss.SSS')}" encode="false"/></default-field></field>
+                <field name="thread_name"><default-field title="thread_name" container-style="text-nowrap ${levelStyle}"><display text="${thread_name}(${thread_id}:${thread_priority})"/></default-field></field>
+                <field name="level"><default-field title="level" container-style="${levelStyle}"><display/></default-field></field>
+                <field name="source_host"><default-field title="source_host" container-style="text-nowrap ${levelStyle}"><display/></default-field></field>
+                <field name="user_id"><default-field title="user_id">
+                    <link url="userAccountDetail" text="${user_id}" link-type="anchor" parameter-map="[userId:user_id]" condition="user_id"/></default-field></field>
+                <field name="visitor_id"><default-field title="visitor_id" container-style="${levelStyle}"><display/></default-field></field>
 
-            <form-list-column><field-ref name="@timestamp"/><field-ref name="thread_name"/></form-list-column>
-            <form-list-column><field-ref name="level"/><field-ref name="source_host"/></form-list-column>
-            <form-list-column><field-ref name="user_id"/><field-ref name="visitor_id"/></form-list-column>
-            <form-list-column><field-ref name="logger_name"/><field-ref name="message"/></form-list-column>
-            <form-list-column><field-ref name="thrownView"/></form-list-column>
-        </form-list>
+                <field name="logger_name"><default-field title="logger_name" container-style="${levelStyle}"><display/></default-field></field>
+                <field name="message">
+                    <conditional-field condition="message != null &amp;&amp; message.length() &gt; 300">
+                        <display text="${message.substring(0, 300)} "/>
+                        <container-dialog id="ViewMessage" button-text="All" width="800"><label text="${message}"/></container-dialog>
+                    </conditional-field>
+                    <default-field title="message"><display/></default-field>
+                </field>
+                <field name="thrownView"><conditional-field condition="thrown">
+                    <container-dialog id="ViewThrown" button-text="Thrown" width="960">
+                        <label text="${groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(thrown))}" type="pre"/>
+                    </container-dialog>
+                </conditional-field><default-field title=""><display/></default-field></field>
+
+                <form-list-column><field-ref name="@timestamp"/><field-ref name="thread_name"/></form-list-column>
+                <form-list-column><field-ref name="level"/><field-ref name="source_host"/></form-list-column>
+                <form-list-column><field-ref name="user_id"/><field-ref name="visitor_id"/></form-list-column>
+                <form-list-column><field-ref name="logger_name"/><field-ref name="message"/></form-list-column>
+                <form-list-column><field-ref name="thrownView"/></form-list-column>
+            </form-list>
+
+        </widgets></section>
+
+        <section name="HttpLog" condition="indexName == 'moqui_http_log'"><widgets>
+
+            <form-list name="HttpLogMessageDocuments" list="documentList" paginate="true" paginate-always-show="true" skip-form="true">
+                <row-actions>
+                    <set field="levelStyle" from="'ERROR'.equals(level) ? 'text-danger' : ('WARN'.equals(level) ? 'text-warning' : ('INFO'.equals(level) ? 'text-success' : ''))"/>
+                </row-actions>
+                <field name="@timestamp"><default-field container-style="text-nowrap ${levelStyle}">
+                    <display text="${ec.l10n.format(new Timestamp(context.get('@timestamp')), 'yyyy-MM-dd HH:mm:ss.SSS')}" encode="false"/></default-field></field>
+                <field name="remote_ip"><default-field><display/></default-field></field>
+                <field name="remote_user"><default-field><display/></default-field></field>
+                <field name="content_type"><default-field><display/></default-field></field>
+                <field name="request_method"><default-field><display/></default-field></field>
+                <field name="request_scheme"><default-field><display/></default-field></field>
+                <field name="request_host"><default-field><display/></default-field></field>
+                <field name="request_path"><default-field><display/></default-field></field>
+                <field name="request_query">
+                    <conditional-field condition="request_query != null &amp;&amp; request_query.length() &gt; 80">
+                        <display text="${request_query.substring(0, 80)} "/>
+                        <container-dialog id="ViewRequestQuery" button-text="All" width="800"><label text="${request_query}"/></container-dialog>
+                    </conditional-field>
+                    <default-field><display/></default-field>
+                </field>
+                <field name="http_version"><default-field><display/></default-field></field>
+                <field name="response"><default-field><display/></default-field></field>
+                <field name="time_initial_ms"><default-field><display/></default-field></field>
+                <field name="time_final_ms"><default-field><display/></default-field></field>
+                <field name="bytes"><default-field><display/></default-field></field>
+                <field name="referrer"><default-field><display/></default-field></field>
+                <field name="agent"><default-field><display/></default-field></field>
+                <field name="session"><default-field><display/></default-field></field>
+                <field name="visitor_id"><default-field><display/></default-field></field>
+
+                <form-list-column><field-ref name="@timestamp"/><field-ref name="time_initial_ms"/><field-ref name="time_final_ms"/></form-list-column>
+                <form-list-column><field-ref name="remote_ip"/><field-ref name="remote_user"/></form-list-column>
+                <form-list-column><field-ref name="request_host"/><field-ref name="request_method"/><field-ref name="request_scheme"/></form-list-column>
+                <form-list-column><field-ref name="http_version"/><field-ref name="response"/><field-ref name="bytes"/></form-list-column>
+                <form-list-column><field-ref name="referrer"/><field-ref name="request_path"/><field-ref name="request_query"/></form-list-column>
+                <form-list-column><field-ref name="session"/><field-ref name="visitor_id"/><field-ref name="agent"/></form-list-column>
+
+            </form-list>
+
+        </widgets></section>
+
     </widgets>
 </screen>


### PR DESCRIPTION
Add a way to visualize and search the moqui_http_log index along the moqui_logs index.

Changed the text-line to specify the index to a drop-down, with both known indexes. Each index is rendered using a specific section as the fields are different.