### PR TITLE
In MessageRemoteDetail.xml screen show the message remote enum and a …

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,6 +52,7 @@ Written in 2018 by Zhang Wei - zhangwei1979
 Written in 2019 by Arlen McDonell - jmcdl
 Written in 2019 by Jacob Barnes - Tellan
 Written in 2019 by Arzang Kasiri - akasiri
+Written in 2021 by Amir Anjomshoaa - amiranjom
 
 ===========================================================================
 
@@ -90,5 +91,6 @@ Written in 2018 by Zhang Wei - zhangwei1979
 Written in 2019 by Arlen McDonell - jmcdl
 Written in 2019 by Jacob Barnes - Tellan
 Written in 2019 by Arzang Kasiri - akasiri
+Written in 2021 by Amir Anjomshoaa - amiranjom
 
 ===========================================================================

--- a/base-component/tools/screen/System/SystemMessage/Remote/MessageRemoteDetail.xml
+++ b/base-component/tools/screen/System/SystemMessage/Remote/MessageRemoteDetail.xml
@@ -20,36 +20,90 @@ along with this software (see the LICENSE.md file). If not, see
     <transition name="updateMessageRemote"><service-call name="update#moqui.service.message.SystemMessageRemote"/>
         <default-response url="."/></transition>
 
+    <transition name="createMessageEnum"><service-call name="create#moqui.service.message.SystemMessageEnumMap"/>
+        <default-response url="."/></transition>
+    <transition name="updateMessageRemoteEnum"><service-call name="update#moqui.service.message.SystemMessageEnumMap"/>
+        <default-response url="."/></transition>
+    <transition name="deleteMessageRemoteEnum"><service-call name="delete#moqui.service.message.SystemMessageEnumMap"/>
+        <default-response url="."/></transition>
+
+    <transition name="systemMessageList"><default-response url="../../Message/SystemMessageList"/></transition>
+
     <actions>
         <entity-find-one entity-name="moqui.service.message.SystemMessageRemote" value-field="systemMessageRemote"/>
+
+        <entity-find entity-name="moqui.service.message.SystemMessageEnumMap" list="systemMessageEnumMapList">
+            <econdition field-name="systemMessageRemoteId"/></entity-find>
     </actions>
     <widgets>
-        <form-single name="SystemMessageRemoteForm" map="systemMessageRemote" transition="updateMessageRemote">
-            <field name="systemMessageRemoteId"><default-field title="Message Remote ID"><display/></default-field></field>
-            <auto-fields-entity entity-name="moqui.service.message.SystemMessageRemote" field-type="edit" include="nonpk"/>
-            <field name="description"><default-field><text-line size="40"/></default-field></field>
-            <field name="sendUrl"><default-field><text-line size="100"/></default-field></field>
-            <field name="sendServiceName"><default-field><text-line size="100"/></default-field></field>
-            <field name="messageAuthEnumId"><default-field title="Message Auth">
-                <widget-template-include location="component://webroot/template/screen/BasicWidgetTemplates.xml#enumDropDown">
-                    <set field="enumTypeId" value="SystemMessageAuthType"/><set field="allowEmpty" value="true"/></widget-template-include>
-            </default-field></field>
-            <field name="sendAuthEnumId"><default-field title="Message Send Auth">
-                <widget-template-include location="component://webroot/template/screen/BasicWidgetTemplates.xml#enumDropDown">
-                    <set field="enumTypeId" value="SystemMessageAuthType"/><set field="allowEmpty" value="true"/></widget-template-include>
-            </default-field></field>
-            <field name="systemMessageTypeId"><default-field title="Message Type">
-                <drop-down allow-empty="true">
-                    <entity-options key="${systemMessageTypeId}" text="${description}">
-                        <entity-find entity-name="moqui.service.message.SystemMessageType">
-                            <order-by field-name="description"/></entity-find></entity-options>
-                </drop-down>
-            </default-field></field>
-            <field name="segmentTerminator"><default-field><text-line size="1" maxlength="1"/></default-field></field>
-            <field name="elementSeparator"><default-field><text-line size="1" maxlength="1"/></default-field></field>
-            <field name="componentDelimiter"><default-field><text-line size="1" maxlength="1"/></default-field></field>
-            <field name="escapeCharacter"><default-field><text-line size="1" maxlength="1"/></default-field></field>
-            <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
-        </form-single>
+        <container-row>
+            <row-col lg="7">
+                <link url="systemMessageList" text="Messages" parameter-map="[systemMessageRemoteId:systemMessageRemoteId]"/>
+
+                <form-single name="SystemMessageRemoteForm" map="systemMessageRemote" transition="updateMessageRemote">
+                    <field name="systemMessageRemoteId"><default-field title="Message Remote ID"><display/></default-field></field>
+                    <auto-fields-entity entity-name="moqui.service.message.SystemMessageRemote" field-type="edit" include="nonpk"/>
+                    <field name="description"><default-field><text-line size="40"/></default-field></field>
+                    <field name="sendUrl"><default-field><text-line size="100"/></default-field></field>
+                    <field name="sendServiceName"><default-field><text-line size="100"/></default-field></field>
+                    <field name="messageAuthEnumId"><default-field title="Message Auth">
+                        <widget-template-include location="component://webroot/template/screen/BasicWidgetTemplates.xml#enumDropDown">
+                            <set field="enumTypeId" value="SystemMessageAuthType"/><set field="allowEmpty" value="true"/></widget-template-include>
+                    </default-field></field>
+                    <field name="sendAuthEnumId"><default-field title="Message Send Auth">
+                        <widget-template-include location="component://webroot/template/screen/BasicWidgetTemplates.xml#enumDropDown">
+                            <set field="enumTypeId" value="SystemMessageAuthType"/><set field="allowEmpty" value="true"/></widget-template-include>
+                    </default-field></field>
+                    <field name="systemMessageTypeId"><default-field title="Message Type">
+                        <drop-down allow-empty="true">
+                            <entity-options key="${systemMessageTypeId}" text="${description}">
+                                <entity-find entity-name="moqui.service.message.SystemMessageType">
+                                    <order-by field-name="description"/></entity-find></entity-options>
+                        </drop-down>
+                    </default-field></field>
+                    <field name="segmentTerminator"><default-field><text-line size="1" maxlength="1"/></default-field></field>
+                    <field name="elementSeparator"><default-field><text-line size="1" maxlength="1"/></default-field></field>
+                    <field name="componentDelimiter"><default-field><text-line size="1" maxlength="1"/></default-field></field>
+                    <field name="escapeCharacter"><default-field><text-line size="1" maxlength="1"/></default-field></field>
+                    <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
+                </form-single>
+            </row-col>
+            <row-col lg="5">
+                <container-box><box-header title="Message Remote Enum"/><box-toolbar>
+                    <container-dialog id="createMessageEnum" button-text="Create Message Remote Enum">
+                        <form-single name="CreateMessageEnum" transition="createMessageRemoteEnum">
+                            <field name="systemMessageRemoteId"><default-field><hidden/></default-field></field>
+                            <field name="enumId"><default-field>
+                                <drop-down>
+                                    <entity-options key="${enumId}" text="${description}">
+                                        <entity-find entity-name="moqui.basic.Enumeration">
+                                            <econdition field-name="enumTypeId" value="SystemMessageRemoteParameter"/>
+                                            <order-by field-name="sequenceNum,description"/>
+                                        </entity-find>
+                                    </entity-options>
+                                </drop-down>
+                            </default-field></field>
+                            <field name="mappedValue"><default-field><text-line size="30"/></default-field></field>
+                            <field name="submitButton"><default-field title="Add"><submit/></default-field></field>
+                        </form-single>
+                    </container-dialog>
+                </box-toolbar><box-body-nopad>
+                    <form-list name="SystemMessageEnumMapList" list="systemMessageEnumMapList" transition="updateMessageRemoteEnum">
+                        <row-actions>
+                            <entity-find-one entity-name="moqui.basic.Enumeration" value-field="keyEnum">
+                                <field-map field-name="enumId"/></entity-find-one>
+                        </row-actions>
+                        <field name="systemMessageRemoteId"><default-field><hidden/></default-field></field>
+                        <field name="enumId"><default-field title="Enum Id">
+                            <display text="${keyEnum ? keyEnum.description + ' ' : ''}(${enumId})"/></default-field></field>
+                        <field name="mappedValue"><default-field title="Value"><text-line size="30"/></default-field></field>
+                        <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
+                        <field name="lastUpdatedStamp"><default-field><hidden/></default-field></field>
+                        <field name="deleteButton"><default-field title="">
+                            <link url="deleteMessageRemoteEnum" text=" " icon="fa fa-trash" confirmation="Really remove?"/></default-field></field>
+                    </form-list>
+                </box-body-nopad></container-box>
+            </row-col>
+        </container-row>
     </widgets>
 </screen>

--- a/base-component/tools/screen/System/SystemMessage/Remote/MessageRemoteDetail.xml
+++ b/base-component/tools/screen/System/SystemMessage/Remote/MessageRemoteDetail.xml
@@ -67,8 +67,8 @@ along with this software (see the LICENSE.md file). If not, see
                 </form-single>
             </row-col>
             <row-col lg="5">
-                <container-box><box-header title="Message Enum Map"/><box-toolbar>
-                    <container-dialog id="createMessageRemoteEnumMap" button-text="Create Message Enum Map">
+                <container-box><box-header title="Message Remote Enum Map"/><box-toolbar>
+                    <container-dialog id="createMessageRemoteEnumMap" button-text="Create Message Remote Enum Map">
                         <form-single name="CreateMessageRemoteEnumMap" transition="createMessageRemoteEnumMap">
                             <field name="systemMessageRemoteId"><default-field><hidden/></default-field></field>
                             <field name="enumId"><default-field><drop-down>

--- a/base-component/tools/screen/System/SystemMessage/Remote/MessageRemoteDetail.xml
+++ b/base-component/tools/screen/System/SystemMessage/Remote/MessageRemoteDetail.xml
@@ -20,11 +20,11 @@ along with this software (see the LICENSE.md file). If not, see
     <transition name="updateMessageRemote"><service-call name="update#moqui.service.message.SystemMessageRemote"/>
         <default-response url="."/></transition>
 
-    <transition name="createMessageEnum"><service-call name="create#moqui.service.message.SystemMessageEnumMap"/>
+    <transition name="createMessageRemoteEnumMap"><service-call name="create#moqui.service.message.SystemMessageEnumMap"/>
         <default-response url="."/></transition>
-    <transition name="updateMessageRemoteEnum"><service-call name="update#moqui.service.message.SystemMessageEnumMap"/>
+    <transition name="updateMessageRemoteEnumMap"><service-call name="update#moqui.service.message.SystemMessageEnumMap"/>
         <default-response url="."/></transition>
-    <transition name="deleteMessageRemoteEnum"><service-call name="delete#moqui.service.message.SystemMessageEnumMap"/>
+    <transition name="deleteMessageRemoteEnumMap"><service-call name="delete#moqui.service.message.SystemMessageEnumMap"/>
         <default-response url="."/></transition>
 
     <transition name="systemMessageList"><default-response url="../../Message/SystemMessageList"/></transition>
@@ -54,13 +54,11 @@ along with this software (see the LICENSE.md file). If not, see
                         <widget-template-include location="component://webroot/template/screen/BasicWidgetTemplates.xml#enumDropDown">
                             <set field="enumTypeId" value="SystemMessageAuthType"/><set field="allowEmpty" value="true"/></widget-template-include>
                     </default-field></field>
-                    <field name="systemMessageTypeId"><default-field title="Message Type">
-                        <drop-down allow-empty="true">
-                            <entity-options key="${systemMessageTypeId}" text="${description}">
-                                <entity-find entity-name="moqui.service.message.SystemMessageType">
-                                    <order-by field-name="description"/></entity-find></entity-options>
-                        </drop-down>
-                    </default-field></field>
+                    <field name="systemMessageTypeId"><default-field title="Message Type"><drop-down allow-empty="true">
+                        <entity-options key="${systemMessageTypeId}" text="${description}">
+                            <entity-find entity-name="moqui.service.message.SystemMessageType">
+                                <order-by field-name="description"/></entity-find></entity-options>
+                    </drop-down></default-field></field>
                     <field name="segmentTerminator"><default-field><text-line size="1" maxlength="1"/></default-field></field>
                     <field name="elementSeparator"><default-field><text-line size="1" maxlength="1"/></default-field></field>
                     <field name="componentDelimiter"><default-field><text-line size="1" maxlength="1"/></default-field></field>
@@ -69,38 +67,34 @@ along with this software (see the LICENSE.md file). If not, see
                 </form-single>
             </row-col>
             <row-col lg="5">
-                <container-box><box-header title="Message Remote Enum"/><box-toolbar>
-                    <container-dialog id="createMessageEnum" button-text="Create Message Remote Enum">
-                        <form-single name="CreateMessageEnum" transition="createMessageRemoteEnum">
+                <container-box><box-header title="Message Enum Map"/><box-toolbar>
+                    <container-dialog id="createMessageRemoteEnumMap" button-text="Create Message Enum Map">
+                        <form-single name="CreateMessageRemoteEnumMap" transition="createMessageRemoteEnumMap">
                             <field name="systemMessageRemoteId"><default-field><hidden/></default-field></field>
-                            <field name="enumId"><default-field>
-                                <drop-down>
-                                    <entity-options key="${enumId}" text="${description}">
-                                        <entity-find entity-name="moqui.basic.Enumeration">
-                                            <econdition field-name="enumTypeId" value="SystemMessageRemoteParameter"/>
-                                            <order-by field-name="sequenceNum,description"/>
-                                        </entity-find>
-                                    </entity-options>
-                                </drop-down>
-                            </default-field></field>
+                            <field name="enumId"><default-field><drop-down>
+                                <entity-options key="${enumId}" text="${description}">
+                                    <entity-find entity-name="moqui.basic.Enumeration">
+                                        <econdition field-name="enumTypeId" value="SystemMessageRemoteParameter"/>
+                                        <order-by field-name="sequenceNum,description"/>
+                                    </entity-find>
+                                </entity-options>
+                            </drop-down></default-field></field>
                             <field name="mappedValue"><default-field><text-line size="30"/></default-field></field>
                             <field name="submitButton"><default-field title="Add"><submit/></default-field></field>
                         </form-single>
                     </container-dialog>
                 </box-toolbar><box-body-nopad>
-                    <form-list name="SystemMessageEnumMapList" list="systemMessageEnumMapList" transition="updateMessageRemoteEnum">
-                        <row-actions>
-                            <entity-find-one entity-name="moqui.basic.Enumeration" value-field="keyEnum">
-                                <field-map field-name="enumId"/></entity-find-one>
-                        </row-actions>
+                    <form-list name="SystemMessageEnumMapList" list="systemMessageEnumMapList" transition="updateMessageRemoteEnumMap">
+                        <row-actions><entity-find-one entity-name="moqui.basic.Enumeration" value-field="keyEnum">
+                                <field-map field-name="enumId"/></entity-find-one></row-actions>
                         <field name="systemMessageRemoteId"><default-field><hidden/></default-field></field>
                         <field name="enumId"><default-field title="Enum Id">
                             <display text="${keyEnum ? keyEnum.description + ' ' : ''}(${enumId})"/></default-field></field>
-                        <field name="mappedValue"><default-field title="Value"><text-line size="30"/></default-field></field>
+                        <field name="mappedValue"><default-field title="Value"><text-line/></default-field></field>
                         <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
                         <field name="lastUpdatedStamp"><default-field><hidden/></default-field></field>
                         <field name="deleteButton"><default-field title="">
-                            <link url="deleteMessageRemoteEnum" text=" " icon="fa fa-trash" confirmation="Really remove?"/></default-field></field>
+                            <link url="deleteMessageRemoteEnumMap" text=" " icon="fa fa-trash" confirmation="Really remove?"/></default-field></field>
                     </form-list>
                 </box-body-nopad></container-box>
             </row-col>


### PR DESCRIPTION
…button to system messages for the message remote
The primary purpose for this PR is to add a container box to the screen Message Remote Detail to give the accessibility to the user to change the Message Remote Enums in the same screen as configuring the Message Remote itself. I'm proposing to add this container box for Message Remote Enums to allow a convenient way to configure both together and a link/button to allow easy access to System Messages related to the Message Remote.