### PR TITLE
Squash commit for Add Second Factor Authentication to Moqui project

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ that are otherwise encumbered.
 Signed by git commit adding my legal name and git username:
 
 Written in 2010-2020 by David E. Jones - jonesde
+Written in 2021-2021 by D. Michael Jones - acetousk
 Written in 2014-2015 by Solomon Bessire - sbessire
 Written in 2014-2015 by Jacopo Cappellato - jacopoc
 Written in 2014-2015 by Abdullah Shaikh - abdullahs
@@ -75,6 +76,7 @@ litigation is filed.
 Signed by git commit adding my legal name and git username:
 
 Written in 2010-2020 by David E. Jones - jonesde
+Written in 2021-2021 by D. Michael Jones - acetousk
 Written in 2014-2015 by Solomon Bessire - sbessire
 Written in 2014-2015 by Jacopo Cappellato - jacopoc
 Written in 2014-2016 by Yao Chunlin - chunlinyao

--- a/base-component/tools/screen/System/Security/UserAccount/UserAccountDetail.xml
+++ b/base-component/tools/screen/System/Security/UserAccount/UserAccountDetail.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all
@@ -38,6 +38,19 @@ along with this software (see the LICENSE.md file). If not, see
     <transition name="updateUserGroupMember"><service-call name="update#moqui.security.UserGroupMember"/>
         <default-response url="."/></transition>
 
+    <transition name="createUserAuthcFactorTotp"><service-call name="org.moqui.impl.UserServices.create#UserAuthcFactorTotp"/>
+        <default-response url="."/></transition>
+    <transition name="verifyUserAuthcFactorTotp"><service-call name="org.moqui.impl.UserServices.verify#UserAuthcFactorTotp"/>
+        <default-response url="."/></transition>
+    <transition name="createUserAuthcFactorSingleUse">
+        <service-call name="org.moqui.impl.UserServices.create#SingleUseAuthcCodes" />
+        <actions><script>ec.web.sessionAttributes.put("singleUseCodes", singleUseCodes)</script></actions>
+        <default-response url="."/></transition>
+    <transition name="createUserAuthcFactorEmail"><service-call name="org.moqui.impl.UserServices.create#EmailUserAuthcFactor"/>
+        <default-response url="."/></transition>
+    <transition name="factorSubmit"><service-call name="org.moqui.impl.UserServices.invalidate#UserAuthcFactorEntry"/>
+        <default-response url="."/></transition>
+
     <transition name="createUserPreference"><service-call name="create#moqui.security.UserPreference"/>
         <default-response url="."/></transition>
     <transition name="updateUserPreference"><service-call name="update#moqui.security.UserPreference"/>
@@ -56,13 +69,19 @@ along with this software (see the LICENSE.md file). If not, see
     <actions>
         <entity-find-one entity-name="moqui.security.UserAccount" value-field="userAccount"/>
 
+        <set field="singleUseCodes" from="ec.web.sessionAttributes.remove('singleUseCodes')"/>
         <set field="localeStringList" from="[]"/>
+
         <iterate list="Locale.getAvailableLocales()" entry="lcl"><script>localeStringList.add([locale:lcl.toString(), name:lcl.getDisplayName(ec.user.locale)])</script></iterate>
         <order-map-list list="localeStringList"><order-by field-name="name"/></order-map-list>
 
+        <entity-find entity-name="moqui.security.UserAuthcFactor" list="userAuthcFactorList">
+            <date-filter/>
+            <econdition field-name="userId"/>
+        </entity-find>
+
         <entity-find entity-name="moqui.security.UserGroupMember" list="ugmList">
             <econdition field-name="userId"/><order-by field-name="userGroupId"/></entity-find>
-
         <entity-find entity-name="moqui.security.UserPreference" list="upList">
             <econdition field-name="userId"/><order-by field-name="preferenceKey"/></entity-find>
         <entity-find entity-name="moqui.security.user.NotificationTopic" list="notificationTopicList">
@@ -240,6 +259,91 @@ along with this software (see the LICENSE.md file). If not, see
                             <link url="deleteUserPreference" text=" " icon="fa fa-trash" confirmation="Really remove?"/></default-field></field>
                     </form-list>
                 </box-body-nopad></container-box>
+
+                <section name="SingleUseCodesDisplay" condition="singleUseCodes">
+                    <actions>
+                        <set field="singleUseCodes1" from="[]"/><set field="singleUseCodes2" from="[]"/><set field="singleUseCodes3" from="[]"/>
+                        <script>
+                            int i;
+                            for(code in singleUseCodes){
+                                if( i%3 == 0 ) { singleUseCodes1.add(singleUseCodes[i]);}
+                                else if(i%3==1){ singleUseCodes2.add(singleUseCodes[i]);}
+                                else if(i%3==2){ singleUseCodes3.add(singleUseCodes[i]);}
+                                i++; }</script>
+                    </actions>
+                    <widgets>
+                        <container-box>
+                            <box-header><label text="Single Use Codes" style="text-danger" type="h5"/></box-header>
+                            <box-body>
+                                <label text="Write down these codes. They will only appear once." style="text-danger"/>
+                                <container-row>
+                                    <row-col lg="4">
+                                        <container type="ul">
+                                            <section-iterate name="SingleUseCodes1" list="singleUseCodes1" entry="code1">
+                                                <widgets><container type="li"><label text="${code1}" style="text-danger"/></container></widgets></section-iterate>
+                                        </container></row-col>
+                                    <row-col lg="4">
+                                        <container type="ul">
+                                            <section-iterate name="SingleUseCodes2" list="singleUseCodes2" entry="code2">
+                                                <widgets><container type="li"><label text="${code2}" style="text-danger"/></container></widgets>
+                                            </section-iterate></container></row-col>
+                                    <row-col lg="4">
+                                        <container type="ul">
+                                            <section-iterate name="SingleUseCodes3" list="singleUseCodes3" entry="code3">
+                                                <widgets><container type="li"><label text="${code3}" style="text-danger"/></container></widgets>
+                                            </section-iterate></container></row-col>
+                                </container-row>
+                            </box-body></container-box>
+                    </widgets>
+                </section>
+                <container-box><box-header title="Authentication Methods"/>
+                    <box-toolbar>
+                        <container-dialog id="CreateTotpDialog" button-text="Add Authenticator App">
+                            <form-single name="CreateUserAuthcFactorTotp" transition="createUserAuthcFactorTotp">
+                                <field name="userId" from="userAccount.userId"><default-field><hidden/></default-field></field>
+                                <field name="thruDate" from="ec.user.nowTimestamp + 365"><default-field><date-time/></default-field></field>
+                                <field name="submitButton"><default-field title="Add"><submit/></default-field></field>
+                            </form-single></container-dialog>
+                        <container-dialog id="AddSingleUseDialog" button-text="Add Single Use Codes">
+                            <form-single name="CreateUserAuthcFactorSingleUse" transition="createUserAuthcFactorSingleUse">
+                                <field name="userId" from="userId"><default-field><hidden/></default-field></field>
+                                <field name="fromDate" from="ec.user.nowTimestamp + 365"><default-field><date-time/></default-field></field>
+                                <field name="numberOfCodes"><default-field title="Number of Codes"><text-line size="30" input-type="Integer" default-value="6"/></default-field></field>
+                                <field name="submitButton"><default-field title="Add" ><submit/></default-field></field>
+                            </form-single></container-dialog>
+                        <container-dialog id="AddEmailFactor" button-text="Add Email Factor">
+                            <form-single name="CreateUserAuthcFactorEmail" transition="createUserAuthcFactorEmail">
+                                <field name="userId" from="userId"><default-field><hidden/></default-field></field>
+                                <field name="thruDate" from="ec.user.nowTimestamp + 365"><default-field><date-time/></default-field></field>
+                                <field name="factorOption" from="userAccount.emailAddress"><default-field title="Email"><text-line size="30"/></default-field></field>
+                                <field name="submitButton"><default-field title="Add"><submit/></default-field></field>
+                            </form-single>
+                        </container-dialog>
+
+                    </box-toolbar><box-body-nopad>
+                        <form-list name="UserAuthcFactorList" list="userAuthcFactorList" transition="factorSubmit">
+                            <field name="factorId">
+                                <header-field title="Id" show-order-by="true"/><default-field><display/></default-field></field>
+                            <field name="userId" from="userId"><default-field><hidden/></default-field></field>
+                            <field name="fromFactorId"><header-field title="From Id"/><default-field><display/></default-field></field>
+                            <field name="factorTypeEnumId"><header-field title="Factor Type"/><default-field><display-entity entity-name="moqui.basic.Enumeration" text="${description}"/></default-field></field>
+                            <field name="fromDate"><default-field><display/></default-field></field>
+                            <field name="thruDate"><default-field><display/></default-field></field>
+                            <field name="action">
+                                <conditional-field condition="needsValidation == 'Y' &amp;&amp; factorTypeEnumId == 'UafTotp'">
+                                    <dynamic-dialog id="VerifyTotpDialog" button-text="Verify" transition="VerifyTotp" parameter-map="[userId:userId, factorId:factorId, verify:true]"/></conditional-field>
+                                <conditional-field condition="needsValidation == 'N' &amp;&amp; factorTypeEnumId == 'UafTotp'">
+                                    <dynamic-dialog id="ViewTotpDialog" button-text="View" transition="VerifyTotp" parameter-map="[userId:userId, factorId:factorId, verify:true]"/></conditional-field>
+                                <conditional-field condition="needsValidation == 'Y' &amp;&amp; factorTypeEnumId == 'UafEmail'">
+                                    <dynamic-dialog id="VerifyEmailDialog" button-text="Verify" transition="VerifyEmail" parameter-map="[userId:userId, factorId:factorId, userEmail:factorOption]"/></conditional-field>
+                                <conditional-field condition="needsValidation == 'N' &amp;&amp; factorTypeEnumId == 'UafEmail'">
+                                    <label text="${factorOption}"/></conditional-field>
+                            </field>
+                            <field name="needsValidation"><conditional-field condition="factorTypeEnumId != 'UafSingleUse'"><label text="${needsValidation}"/></conditional-field></field>
+                            <field name="delete"><default-field title=" "><submit text=" " icon="fa fa-trash"/></default-field></field>
+                        </form-list>
+                    </box-body-nopad>
+                </container-box>
 
                 <!-- TODO: consider adding full history to another screen (tab); now limited to most recent 20 -->
                 <label text="Login History" type="h5"/>

--- a/base-component/tools/screen/System/Security/UserGroup/UserGroupDetail.xml
+++ b/base-component/tools/screen/System/Security/UserGroup/UserGroupDetail.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all
@@ -75,7 +75,8 @@ along with this software (see the LICENSE.md file). If not, see
                 </default-field></field>
                 <field name="ipAllowed"><default-field title="IPs Allowed" tooltip="Comma separated IP4 patterns, each may use '*' for wildcard or '-' separated min/max numbers">
                     <text-line size="80"/></default-field></field>
-
+                <field name="requireAuthcFactor"><default-field title="Require Authc Factor">
+                    <radio no-current-selected-key="N"><option key="Y"/><option key="N"/></radio></default-field></field>
                 <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
             </form-single>
 

--- a/base-component/webroot/data/WebrootSecurityDemoData.xml
+++ b/base-component/webroot/data/WebrootSecurityDemoData.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all

--- a/base-component/webroot/screen/webroot/Login.xml
+++ b/base-component/webroot/screen/webroot/Login.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all
@@ -15,7 +15,9 @@ along with this software (see the LICENSE.md file). If not, see
 <screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/xml-screen-2.1.xsd"
         default-menu-include="false" require-authentication="false" history="false">
 
-    <transition name="login" require-session-token="false"><actions><script>ec.user.loginUser(username, password)</script></actions>
+    <transition name="login" require-session-token="false">
+        <actions><script>ec.user.loginUser(username, password)</script></actions>
+        <conditional-response url="../SecondFactor"><condition><expression>ec.web.sessionAttributes.moquiAuthcFactorRequired</expression></condition></conditional-response>
         <default-response type="screen-last"/><error-response url="."/></transition>
     <transition name="logout"><actions><script>ec.user.logoutUser()</script></actions>
         <default-response url="/"/><error-response url="."/></transition>

--- a/base-component/webroot/screen/webroot/qapps.xml
+++ b/base-component/webroot/screen/webroot/qapps.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all


### PR DESCRIPTION
The pull request makes changes to moqui-framework, moqui-runtime, and SimpleScreens.

The biggest things to check are:

    In my development environment, I was occasionally getting 28 second loading screens when calling services in UserServices.xml to create a UserAuthcFactor. Make sure that in other environments this doesn't happen.
    Ensure that the forms don't allow the user to specify their userId so that permissions for users are enforced.

In moqui-runtime:

    Add a authentication configuration method to UserAccountDetail.xml including features:
        Add any type of authentication method for any user
        Verify authentication types like authenticator app (totp) and email (NOTE: It currently does not matter if a user's authentication type is verified before it is used. In the future this probably will become necessary)
        Invalidate any type of authentication method for any user
    Change Login screen so that it will require the user to go to the SecondFactor screen if a second factor is required
    Add SecondFactor screen for verifying an Authentication factor
