### PR TITLE
Remove redundant information in Tab Title for Entity Detail screen

### DIFF
--- a/base-component/tools/screen/Tools/Entity/DataEdit/EntityDetail.xml
+++ b/base-component/tools/screen/Tools/Entity/DataEdit/EntityDetail.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all
@@ -14,7 +14,7 @@ along with this software (see the LICENSE.md file). If not, see
 -->
 <screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/xml-screen-2.1.xsd"
-        default-menu-title="Entity Detail">
+        default-menu-title="Detail">
 
     <parameter name="selectedEntity" required="true"/>
     <parameter name="refresh" required="false"/>


### PR DESCRIPTION
When using the `EntityDetail` screen, with more than one tab, you are unable to see what entity it is that you are editing. This makes it more difficult to differentiate between different entities when viewing them in this screen.

This PR removes redundant information in the tab title to from: `Entities - Entity Detail (moqui.example)` to `Entities - Detail (moqui.example)`. This allows in the browser tab title to see some relevant information rather than none.

This also follows the same convention as the `EntityFind` screen by not having an additional `Entity` word in the title. 

`EntityDetail` screen before change:
![image](https://user-images.githubusercontent.com/29029373/141923742-9de81394-4d63-48d5-bdca-b05eb1e75366.png)

`EntityDetail` screen after change:
![image](https://user-images.githubusercontent.com/29029373/141923817-290146f1-eab2-41a4-94cf-6bd4416bb970.png)
