### PR TITLE
Remove empty lines before <!doctype html>, now it become the first line.

### DIFF
--- a/template/screen-macro/DefaultScreenMacros.any.ftl
+++ b/template/screen-macro/DefaultScreenMacros.any.ftl
@@ -10,7 +10,7 @@ You should have received a copy of the CC0 Public Domain Dedication
 along with this software (see the LICENSE.md file). If not, see
 <http://creativecommons.org/publicdomain/zero/1.0/>.
 -->
-
+<#-- NOTE: no empty lines before the first #macro otherwise FTL outputs empty lines -->
 <#-- ==================== Includes ==================== -->
 <#macro "include-screen">${sri.renderIncludeScreen(.node["@location"], .node["@share-scope"]!)}</#macro>
 
@@ -28,9 +28,11 @@ along with this software (see the LICENSE.md file). If not, see
 <#macro renderText textNode>
     <#if textNode["@location"]?has_content>
         <#assign textLocation = ec.getResource().expandNoL10n(textNode["@location"], "")>
-        <#if sri.doBoundaryComments() && textNode["@no-boundary-comment"]! != "true"><!-- BEGIN render-mode.text[@location=${textLocation}][@template=${textNode["@template"]!"true"}] --></#if>
+        <#if sri.doBoundaryComments() && textNode["@no-boundary-comment"]! != "true">
+        <!-- BEGIN render-mode.text[@location=${textLocation}][@template=${textNode["@template"]!"true"}] -->
+        </#if>
         <#-- NOTE: this still won't encode templates that are rendered to the writer -->
-        <#if .node["@encode"]! == "true">${sri.renderText(textLocation, textNode["@template"]!)?html}<#else>${sri.renderText(textLocation, textNode["@template"]!)}</#if>
+        <#t><#if .node["@encode"]! == "true">${sri.renderText(textLocation, textNode["@template"]!)?html}<#else>${sri.renderText(textLocation, textNode["@template"]!)}</#if>
         <#if sri.doBoundaryComments() && textNode["@no-boundary-comment"]! != "true"><!-- END   render-mode.text[@location=${textLocation}][@template=${textNode["@template"]!"true"}] --></#if>
     </#if>
     <#assign inlineTemplateSource = textNode.@@text!>

--- a/template/screen-macro/DefaultScreenMacros.html.ftl
+++ b/template/screen-macro/DefaultScreenMacros.html.ftl
@@ -13,10 +13,13 @@ along with this software (see the LICENSE.md file). If not, see
 -->
 <#-- NOTE: no empty lines before the first #macro otherwise FTL outputs empty lines -->
 <#include "DefaultScreenMacros.any.ftl"/>
+<#-- NOTE: no empty lines between the #include and the first #macro otherwise FTL outputs empty lines-->
 <#macro @element><p>=== Doing nothing for element ${.node?node_name}, not yet implemented. ===</p></#macro>
 <#macro screen><#recurse></#macro>
 <#macro widgets><#t>
-    <#if sri.doBoundaryComments()><!-- BEGIN screen[@location=${sri.getActiveScreenDef().location}].widgets --></#if>
+    <#if sri.doBoundaryComments()>
+    <!-- BEGIN screen[@location=${sri.getActiveScreenDef().location}].widgets -->
+    </#if>
     <#recurse>
     <#if sri.doBoundaryComments()><!-- END   screen[@location=${sri.getActiveScreenDef().location}].widgets --></#if>
 </#macro>

--- a/template/screen-macro/ScreenHtmlMacros.ftl
+++ b/template/screen-macro/ScreenHtmlMacros.ftl
@@ -10,9 +10,9 @@ You should have received a copy of the CC0 Public Domain Dedication
 along with this software (see the LICENSE.md file). If not, see
 <http://creativecommons.org/publicdomain/zero/1.0/>.
 -->
-
+<#-- NOTE: no empty lines before the first #macro otherwise FTL outputs empty lines-->
 <#include "DefaultScreenMacros.html.ftl"/>
-
+<#-- NOTE: no empty lines between the #include and the first #macro otherwise FTL outputs empty lines-->
 <#macro container>
     <#assign divId><@nodeId .node/></#assign>
     <${.node["@type"]!"div"}<#if divId?has_content> id="${divId}"</#if><#if .node["@style"]?has_content> class="${ec.resource.expand(.node["@style"], "")}"</#if>>


### PR DESCRIPTION
Any empty lines around `#include` will be output to html.
Remove extra empty line when `no-boundary-comment = true`