### PR TITLE
Export multiple CSV files out to browser as a single zip

### DIFF
--- a/base-component/tools/screen/Tools/Entity/DataExport.xml
+++ b/base-component/tools/screen/Tools/Entity/DataExport.xml
@@ -70,9 +70,16 @@ along with this software (see the LICENSE.md file). If not, see
                     else if (fileType == 'CSV') response.setContentType('text/csv')
                     else response.setContentType('text/xml')
                     response.setCharacterEncoding("UTF-8")
-                    response.setHeader("Content-Disposition", "attachment; filename=\"EntityExport_${ec.l10n.format(ec.user.nowTimestamp, 'yyyyMMdd_HHmm')}.${fileType == 'JSON' ? 'json' : fileType == 'CSV' ? 'csv' : 'xml'}\";")
                     response.setHeader("Cache-Control", "no-cache, must-revalidate, private")
-                    edw.writer(response.getWriter())
+
+                    if (fileType == 'CSV' && entityNames instanceof List && entityNames.size() > 1) {
+                        // if trying to export more than one entity as CSV, send a .zip file instead
+                        response.setHeader("Content-Disposition", "attachment; filename=\"EntityExport_${ec.l10n.format(ec.user.nowTimestamp, 'yyyyMMdd_HHmm')}.zip\";")
+                        edw.zipDirectory('', response.getOutputStream())
+                    } else {
+                        response.setHeader("Content-Disposition", "attachment; filename=\"EntityExport_${ec.l10n.format(ec.user.nowTimestamp, 'yyyyMMdd_HHmm')}.${fileType == 'JSON' ? 'json' : fileType == 'CSV' ? 'csv' : 'xml'}\";")
+                        edw.writer(response.getWriter())
+                    }
                     noResponse = true
                 }
             ]]></script>

--- a/base-component/tools/screen/Tools/Entity/DataExport.xml
+++ b/base-component/tools/screen/Tools/Entity/DataExport.xml
@@ -67,7 +67,7 @@ along with this software (see the LICENSE.md file). If not, see
                     // stream to ec.web.response
                     def response = ec.web.response
                     if (fileType == 'JSON') response.setContentType('application/json')
-                    if (fileType == 'CSV') response.setContentType('text/csv')
+                    else if (fileType == 'CSV') response.setContentType('text/csv')
                     else response.setContentType('text/xml')
                     response.setCharacterEncoding("UTF-8")
                     response.setHeader("Content-Disposition", "attachment; filename=\"EntityExport_${ec.l10n.format(ec.user.nowTimestamp, 'yyyyMMdd_HHmm')}.${fileType == 'JSON' ? 'json' : fileType == 'CSV' ? 'csv' : 'xml'}\";")

--- a/base-component/tools/screen/Tools/Entity/DataExport.xml
+++ b/base-component/tools/screen/Tools/Entity/DataExport.xml
@@ -66,17 +66,20 @@ along with this software (see the LICENSE.md file). If not, see
                 } else if (context.output == "browser") {
                     // stream to ec.web.response
                     def response = ec.web.response
-                    if (fileType == 'JSON') response.setContentType('application/json')
-                    else if (fileType == 'CSV') response.setContentType('text/csv')
-                    else response.setContentType('text/xml')
                     response.setCharacterEncoding("UTF-8")
                     response.setHeader("Cache-Control", "no-cache, must-revalidate, private")
 
                     if (fileType == 'CSV' && entityNames instanceof List && entityNames.size() > 1) {
                         // if trying to export more than one entity as CSV, send a .zip file instead
+                        response.setContentType('application/zip')
                         response.setHeader("Content-Disposition", "attachment; filename=\"EntityExport_${ec.l10n.format(ec.user.nowTimestamp, 'yyyyMMdd_HHmm')}.zip\";")
                         edw.zipDirectory('', response.getOutputStream())
+
                     } else {
+                        if (fileType == 'JSON') response.setContentType('application/json')
+                        else if (fileType == 'CSV') response.setContentType('text/csv')
+                        else response.setContentType('text/xml')
+
                         response.setHeader("Content-Disposition", "attachment; filename=\"EntityExport_${ec.l10n.format(ec.user.nowTimestamp, 'yyyyMMdd_HHmm')}.${fileType == 'JSON' ? 'json' : fileType == 'CSV' ? 'csv' : 'xml'}\";")
                         edw.writer(response.getWriter())
                     }


### PR DESCRIPTION
When using the "Out to Browser" radio button on the DataExport.xml screen, if the user is trying to export multiple CSV files, automatically group the files into a single .zip file. 

This PR also fixes a bug I introduced in my last PR... :/

Feel free to edit / restyle the code in this PR as you see fit.