### PR TITLE
Add ADMIN_ADV to EX_JOHN_DOE user

### DIFF
--- a/base-component/webroot/data/WebrootSecurityDemoData.xml
+++ b/base-component/webroot/data/WebrootSecurityDemoData.xml
@@ -22,6 +22,7 @@ along with this software (see the LICENSE.md file). If not, see
             passwordHint="framework name, lowercase" currencyUomId="USD" locale="en_US" timeZone="US/Central"
             emailAddress="john.doe@moqui.org"/>
     <moqui.security.UserGroupMember userGroupId="ADMIN" userId="EX_JOHN_DOE" fromDate="1265184000000"/>
+    <moqui.security.UserGroupMember userGroupId="ADMIN_ADV" userId="EX_JOHN_DOE" fromDate="1265184000000"/>
     <moqui.security.UserPermission userPermissionId="ExamplePerm" description="Example Permission"/>
     <moqui.security.UserGroupPermission userGroupId="ADMIN" userPermissionId="ExamplePerm"
             fromDate="1265184000000" thruDate=""/>


### PR DESCRIPTION
Reasoning:
If john.doe doesn't have a feature visible, it's not obvious if a feature exists in Moqui. 

Might as well make it easy for local setups to be able to have john.doe see the groovy shell, and sql runner so that people know they exist and is easy to find on setup or demo.moqui.org