### PR TITLE
Add template macro for qvt to pass through template overrides

### DIFF
--- a/template/screen-macro/DefaultScreenMacros.qvt.ftl
+++ b/template/screen-macro/DefaultScreenMacros.qvt.ftl
@@ -154,6 +154,11 @@ ${sri.renderSectionInclude(.node)}
         </m-container-dialog>
     </#if>
 </#macro>
+<#macro template>
+    <#assign vSlot = "">
+    <#if .node["@v-slot"]?has_content><#assign vSlot = .node["@v-slot"]></#if>
+    <template<#if vSlot?has_content> v-slot:${vSlot}</#if>><#recurse></template>
+</#macro>
 <#macro "dynamic-container">
     <#assign dcDivId><@nodeId .node/></#assign>
     <#assign urlInstance = sri.makeUrlByType(.node["@transition"], "transition", .node, "true").addParameter("_dynamic_container_id", dcDivId)>


### PR DESCRIPTION
This allows for overriding templates in qvt. 

See for example: https://github.com/resistmanagement/resistmanagement/commit/74c8bc239d331c1dbb5043555a69101ff2704f6d#diff-22dfbe277eba683a6668dd6f36329c78128488719ca78807a16960a73a8655aeR91