### PR TITLE
Fix submit on select drop down where there is one result

### DIFF
--- a/base-component/webroot/screen/webroot/js/WebrootVue.qvt.js
+++ b/base-component/webroot/screen/webroot/js/WebrootVue.qvt.js
@@ -1685,7 +1685,7 @@ Vue.component('m-drop-down', {
 
             // console.warn("curOptions updated " + this.name + " allowEmpty " + this.allowEmpty + " value '" + this.value + "' " + " isInNewOptions " + isInNewOptions + ": " + JSON.stringify(options));
             if (!isInNewOptions) {
-                if (!this.allowEmpty && !this.multiple && options && options.length && options[0].value && (!this.requiredManualSelect || options.length === 1)) {
+                if (!this.allowEmpty && !this.multiple && options && options.length && options[0].value && (!this.requiredManualSelect || (!this.submitOnSelect && options.length === 1))) {
                     // simulate normal select behavior with no empty option (not allowEmpty) where first value is selected by default
                     // console.warn("checkCurrentValue setting " + this.name + " to " + options[0].value + " options " + options.length);
                     this.$emit('input', options[0].value);


### PR DESCRIPTION
Scenario:
When there is one result from the dropdown and submit on select is toggled, then there is no way to select from the dropdown so that the submit event is fired. This is especially apparent when no submit button is present, and the user cannot submit the form (which is why this PR is being submitted).