### PR TITLE
allow tracking of artifact hits for rest paths (defaults to false)

### DIFF
--- a/conf/MoquiDevConf.xml
+++ b/conf/MoquiDevConf.xml
@@ -51,7 +51,7 @@
         <cache name="l10n.message" expire-time-idle="600"/>
     </cache-list>
     
-    <server-stats stats-skip-condition="pathInfo?.startsWith('/rpc') || pathInfo?.startsWith('/rest') || pathInfo?.startsWith('/status')">
+    <server-stats stats-skip-condition="pathInfo?.startsWith('/rpc') || pathInfo?.startsWith('/status')">
         <!-- For development, track everything! It'll run slow through... -->
         <artifact-stats type="AT_XML_SCREEN" persist-bin="true" persist-hit="true"/>
         <artifact-stats type="AT_XML_SCREEN_CONTENT" persist-bin="true" persist-hit="true"/>
@@ -59,6 +59,7 @@
         <!-- NOTE: entity-implicit and entity-auto services never persist hits -->
         <artifact-stats type="AT_SERVICE" persist-bin="true" persist-hit="true"/>
         <artifact-stats type="AT_ENTITY" persist-bin="true"/>
+        <artifact-stats type="AT_REST_PATH" persist-bin="true" persist-hit="true"/>
     </server-stats>
 
     <webapp-list>

--- a/conf/MoquiLoadTestConf.xml
+++ b/conf/MoquiLoadTestConf.xml
@@ -5,7 +5,7 @@
     https://github.com/moqui/moqui-framework/blob/master/framework/src/main/resources/MoquiDefaultConf.xml -->
 <moqui-conf xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/moqui-conf-3.xsd">
 
-    <server-stats stats-skip-condition="pathInfo?.startsWith('/rpc') || pathInfo?.startsWith('/rest') || pathInfo?.startsWith('/status')"/>
+    <server-stats stats-skip-condition="pathInfo?.startsWith('/rpc') || pathInfo?.startsWith('/status')"/>
 
     <!-- for load test turn off tarpit -->
     <artifact-execution-facade>

--- a/conf/MoquiProductionConf.xml
+++ b/conf/MoquiProductionConf.xml
@@ -5,7 +5,7 @@
     https://github.com/moqui/moqui-framework/blob/master/framework/src/main/resources/MoquiDefaultConf.xml -->
 <moqui-conf xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/moqui-conf-3.xsd">
 
-    <server-stats stats-skip-condition="pathInfo?.startsWith('/rpc') || pathInfo?.startsWith('/rest') || pathInfo?.startsWith('/status')"/>
+    <server-stats stats-skip-condition="pathInfo?.startsWith('/rpc') || pathInfo?.startsWith('/status')"/>
 
     <!-- NOTE: using the environment variable is relatively secure in a container environment, but for more security set it here instead -->
     <entity-facade crypt-pass="${entity_ds_crypt_pass}" query-stats="true">


### PR DESCRIPTION
Changes to enable tracking of artifact hits for rest paths. Together with PR in moqui-framework repository.