### PR TITLE
Skip createdStamp field in create and edit entity operations

### DIFF
--- a/base-component/tools/screen/Tools/AutoScreen/AutoEdit/AutoEditDetail.xml
+++ b/base-component/tools/screen/Tools/AutoScreen/AutoEdit/AutoEditDetail.xml
@@ -66,6 +66,7 @@ along with this software (see the LICENSE.md file). If not, see
             <container-dialog id="CreateValueDialog" button-text="New ${ec.entity.getEntityDefinition(den).getPrettyName(null, aen)}">
                 <form-single name="CreateEntityValue" transition="create" dynamic="true">
                     <auto-fields-entity entity-name="${den}" field-type="edit"/>
+                    <field name="createdStamp"><default-field><hidden/></default-field></field>
                     <field name="aen"><default-field><hidden/></default-field></field>
                     <field name="den"><default-field><hidden/></default-field></field>
                     <field name="submitButton"><default-field title="Create"><submit/></default-field></field>

--- a/base-component/tools/screen/Tools/AutoScreen/AutoEdit/AutoEditMaster.xml
+++ b/base-component/tools/screen/Tools/AutoScreen/AutoEdit/AutoEditMaster.xml
@@ -121,6 +121,8 @@ along with this software (see the LICENSE.md file). If not, see
             <!-- NOTE: lastUpdatedStamp hidden field added by auto-fields-entity include=nonpk so don't add another hidden field here -->
             <field name="lastUpdatedStamp"><default-field title="Last Updated">
                 <display format="yyyy-MM-dd HH:mm:ss.SSS z" also-hidden="false"/></default-field></field>
+            <field name="createdStamp"><default-field title="Created Updated">
+                <display format="yyyy-MM-dd HH:mm:ss.SSS z" also-hidden="false"/></default-field></field>
             <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
         </form-single>
         <link url="getFormXml" text="Get Form XML" link-type="anchor"/>

--- a/base-component/tools/screen/Tools/AutoScreen/AutoFind.xml
+++ b/base-component/tools/screen/Tools/AutoScreen/AutoFind.xml
@@ -65,6 +65,7 @@ along with this software (see the LICENSE.md file). If not, see
             <container-dialog id="CreateValueDialog" button-text="New Value">
                 <form-single name="CreateEntityValue" transition="create" dynamic="true">
                     <auto-fields-entity entity-name="${aen}" field-type="edit"/>
+                    <field name="createdStamp"><default-field><hidden/></default-field></field>
                     <field name="aen"><default-field><hidden/></default-field></field>
                     <field name="submitButton"><default-field title="Create"><submit/></default-field></field>
                 </form-single>
@@ -91,11 +92,12 @@ along with this software (see the LICENSE.md file). If not, see
                 <default-field title=""><display text=" "/></default-field>
             </field>
             <auto-fields-entity entity-name="${aen}" field-type="find-display"/>
+            <field name="createdStamp"><default-field title="Created Updated"><display format="yyyy-MM-dd HH:mm:ss"/></default-field></field>
             <field name="lastUpdatedStamp"><default-field title="Last Updated"><display format="yyyy-MM-dd HH:mm:ss"/></default-field></field>
-
             <columns>
                 <column><field-ref name="edit"/><field-ref name="delete"/></column>
                 <column><field-ref name="lastUpdatedStamp"/></column>
+                <column><field-ref name="createdStamp"/></column>
             </columns>
         </form-list>
         <link url="getFormXml" text="Get Forms XML" link-type="anchor"/>


### PR DESCRIPTION
- Excludes createdStamp from auto-generated create forms and view definitions
- Keeps the field for internal tracking, but hides it from user facing UIs