### PR TITLE
adding the fix to the addRoute call inside the loadComponent return

### DIFF
--- a/base-component/webroot/screen/webroot/js/WebrootVue.qvt2.js
+++ b/base-component/webroot/screen/webroot/js/WebrootVue.qvt2.js
@@ -2555,6 +2555,7 @@ moqui.webrootVue.component('m-subscreens-active', {
                 console.log('running this.$router.addRoute({ path: '+qvt2FullPath+', component: '+comp+' });');
                 vm.$router.addRoute({
                     path: qvt2FullPath,
+                    name: qvt2FullPath,
                     component: comp
                 });
                 console.log('running this.$router.replace('+qvt2FullPath+');');


### PR DESCRIPTION
The EntityList does not show the new list from the "Filter" action. It seems that adding a "name:qvt2FullPath" member to the addRoute call so that the old route can be deleted. That seems to solve the problem.