### PR TITLE
Render server-provided breadcrumbItems in qvt and vuet headers

### DIFF
--- a/base-component/webroot/screen/includes/WebrootVue.qvt.ftl
+++ b/base-component/webroot/screen/includes/WebrootVue.qvt.ftl
@@ -69,7 +69,16 @@ along with this software (see the LICENSE.md file). If not, see
 
                 <q-icon size="1.5em" name="chevron_right" color="grey" class="gt-xs"></q-icon>
             </template></template>
-            <m-link v-if="navMenuList.length > 0" :href="getNavHref(navMenuList.length - 1)" class="gt-xs">{{navMenuList[navMenuList.length - 1].title}}</m-link>
+            <template v-if="navMenuList.length > 0">
+                <template v-if="navMenuList[navMenuList.length - 1].breadcrumbItems && navMenuList[navMenuList.length - 1].breadcrumbItems.length">
+                    <template v-for="(breadcrumbItem, bcIndex) in navMenuList[navMenuList.length - 1].breadcrumbItems">
+                        <q-icon v-if="bcIndex > 0" size="1.5em" name="chevron_right" color="grey" class="gt-xs"></q-icon>
+                        <m-link v-if="breadcrumbItem.pathWithParams" :href="breadcrumbItem.pathWithParams" class="gt-xs">{{breadcrumbItem.title}}</m-link>
+                        <span v-else class="gt-xs">{{breadcrumbItem.title}}</span>
+                    </template>
+                </template>
+                <m-link v-else :href="getNavHref(navMenuList.length - 1)" class="gt-xs">{{navMenuList[navMenuList.length - 1].title}}</m-link>
+            </template>
 
             <q-space></q-space>
 

--- a/base-component/webroot/screen/includes/WebrootVue.vuet.ftl
+++ b/base-component/webroot/screen/includes/WebrootVue.vuet.ftl
@@ -60,7 +60,16 @@ along with this software (see the LICENSE.md file). If not, see
                     </template>
                 </li>
             </ul>
-            <template v-if="navMenuList.length > 0"><m-link class="navbar-text" :href="getNavHref(navMenuList.length - 1)">{{navMenuList[navMenuList.length - 1].title}}</m-link></template>
+            <template v-if="navMenuList.length > 0">
+                <template v-if="navMenuList[navMenuList.length - 1].breadcrumbItems && navMenuList[navMenuList.length - 1].breadcrumbItems.length">
+                    <template v-for="(breadcrumbItem, bcIndex) in navMenuList[navMenuList.length - 1].breadcrumbItems">
+                        <i v-if="bcIndex > 0" class="fa fa-chevron-right"></i>
+                        <m-link v-if="breadcrumbItem.pathWithParams" class="navbar-text" :href="breadcrumbItem.pathWithParams">{{breadcrumbItem.title}}</m-link>
+                        <span v-else class="navbar-text">{{breadcrumbItem.title}}</span>
+                    </template>
+                </template>
+                <m-link v-else class="navbar-text" :href="getNavHref(navMenuList.length - 1)">{{navMenuList[navMenuList.length - 1].title}}</m-link>
+            </template>
             <#-- logout button -->
             <a href="${sri.buildUrl("/Login/logout").url}" data-toggle="tooltip" data-original-title="${ec.l10n.localize("Logout")} ${(ec.user.userAccount.userFullName)!''}"
                    onclick="return confirm('${ec.l10n.localize("Logout")} ${(ec.user.userAccount.userFullName)!''}?')"


### PR DESCRIPTION
# Render server-provided breadcrumbItems in qvt and vuet headers

## Problem
The header breadcrumb rendering only displayed the default final nav title/path. With backend-provided custom breadcrumb state, UI should render each breadcrumb item with optional links.

## Use Case
Some screens need custom breadcrumb trails (including intermediate links and non-link labels) that differ from default menu depth/title rendering, so users can navigate contextual paths correctly.

## What Changed
- Updated `WebrootVue.qvt.ftl` header breadcrumb area:
  - If `breadcrumbItems` exists on the current nav item, iterate and render each item.
  - Render separators between breadcrumb items.
  - Render `<m-link>` when `pathWithParams` exists; otherwise render plain text.
- Updated `WebrootVue.vuet.ftl` with equivalent behavior.
- Kept existing fallback behavior when `breadcrumbItems` is absent.

## Behavior
- Preferred rendering path:
  - `navMenuList[last].breadcrumbItems`
- Fallback path:
  - Existing single-title/default breadcrumb rendering

## Backward Compatibility
- No UI regression expected for screens that do not provide `breadcrumbItems`.
- Existing menu/nav data remains valid.

## Validation
Manual checks:
1. Open a screen with custom breadcrumb items and verify ordered breadcrumb display and links.
2. Verify a breadcrumb item without `pathWithParams` renders as non-link text.
3. Open a screen without `breadcrumbItems` and verify existing fallback title behavior.
4. Validate both qvt and vuet render modes.

## Reviewer Focus
- Visual consistency between qvt/vuet header breadcrumbs.
- Correct fallback behavior when `breadcrumbItems` is missing.
- Any expected UX edge cases (long labels, many breadcrumb segments).

## Related PR
- Backend menuData PR: https://github.com/moqui/moqui-framework/pull/704#issue-4086777949
