### PR TITLE
fix: add dark background color for .q-drawer in dark mode

### DIFF
--- a/base-component/webroot/screen/webroot/css/WebrootVue.qvt.css
+++ b/base-component/webroot/screen/webroot/css/WebrootVue.qvt.css
@@ -36,6 +36,7 @@ body.test.body--dark #top { background:#224422!important; color:white; }
 */
 
 .body--dark .q-menu { background-color:black; }
+.body--dark .q-drawer { background-color: #121212; }
 .body--dark img.invertible { -webkit-filter: invert(90%); filter: invert(90%); }
 
 @media (min-width:576px) {

--- a/base-component/webroot/screen/webroot/css/WebrootVue.qvt.css
+++ b/base-component/webroot/screen/webroot/css/WebrootVue.qvt.css
@@ -36,7 +36,7 @@ body.test.body--dark #top { background:#224422!important; color:white; }
 */
 
 .body--dark .q-menu { background-color:black; }
-.body--dark .q-drawer { background-color: #121212; }
+.body--dark .q-drawer { background-color: black; }
 .body--dark img.invertible { -webkit-filter: invert(90%); filter: invert(90%); }
 
 @media (min-width:576px) {


### PR DESCRIPTION
## Summary

Fixes the dark mode drawer overlap issue reported in #248.

When the dark theme (`body--dark`) is active, the `.q-drawer` component lacks a background color override, causing it to appear transparent and overlap/blend with other content on horizontal scroll.

## Fix

Added a dark background color override for the drawer in `WebrootVue.qvt.css`, right alongside the existing `.body--dark .q-menu` rule:

```css
.body--dark .q-drawer {
    background-color: black;
}
```

## File Changed

`base-component/webroot/screen/webroot/css/WebrootVue.qvt.css`

## Related Issue

Closes #248